### PR TITLE
Get rid of the duplicated `.kt` file extension

### DIFF
--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/GenerateFunctions.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/GenerateFunctions.kt
@@ -132,7 +132,7 @@ fun generateFunctions(functions: List<FunctionType>): List<FileSpec> {
             val fileSpec = FileSpec
                 .builder(
                     name.toFunctionGroupObjectPackage(namingFlags),
-                    name.toFunctionGroupObjectName(namingFlags) + ".kt",
+                    name.toFunctionGroupObjectName(namingFlags),
                 )
                 .addType(objectSpecBuilder.build())
                 .addImport("kotlinx.coroutines.future", "await")

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/GenerateResources.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/GenerateResources.kt
@@ -247,7 +247,7 @@ fun generateResources(resources: List<ResourceType>): List<FileSpec> {
                     UseCharacteristic.ResourceRoot,
                     LanguageType.Kotlin,
                 ),
-            ) + ".kt",
+            ),
         )
 
         buildArgsClass(file, type)

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/GenerateTypeWithNiceBuilders.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/GenerateTypeWithNiceBuilders.kt
@@ -175,7 +175,7 @@ fun generateTypeWithNiceBuilders(
 
     val fileSpec = FileSpec.builder(
         names.packageName,
-        names.className + ".kt",
+        names.className,
     )
 
     val argsClassName = ClassName(names.packageName, names.className)

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/WriteableFile.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/WriteableFile.kt
@@ -49,6 +49,6 @@ class InMemoryGeneratedFile(private val fileSpec: FileSpec) : WriteableFile {
         OutputStreamWriter(outputStream).use {
             fileSpec.writeTo(it)
         }
-        return fileSpec.name
+        return "${fileSpec.name}.kt"
     }
 }


### PR DESCRIPTION
## Task

Related to #24.

## Description

Some file names included the `.kt` extension two times (`{filename}.kt.kt`). This PR fixes that. For example, `GetInternetGatewayFilterArgs.kt.kt` is now `GetInternetGatewayFilterArgs.kt`
