### PR TITLE
Fix bugs related to type name conflicts, improve `computeSchemaSubset`

### DIFF
--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/MapWithKeyTransformer.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/MapWithKeyTransformer.kt
@@ -18,8 +18,18 @@ internal class MapWithKeyTransformer<K, V> private constructor(
             val transformedMap = mutableMapOf<K, V>()
             baseMap.forEach { (key, value) ->
                 val transformedKey = keyTransformer(key)
-                transformedMap.merge(transformedKey, value) { _, _ ->
-                    throw ConflictsNotAllowed.from(key, transformedKey)
+                transformedMap.merge(transformedKey, value) { oldValue, newValue ->
+                    if (oldValue === newValue) {
+                        newValue
+                    } else if (oldValue == newValue) {
+                        println(
+                            "WARN: Found conflicting keys ($key, $transformedKey), " +
+                                "but values are the same ($oldValue, $newValue).",
+                        )
+                        newValue
+                    } else {
+                        throw ConflictsNotAllowed.from(key, transformedKey)
+                    }
                 }
             }
             return MapWithKeyTransformer(transformedMap, keyTransformer)

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/SetWithKeyTransformer.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/SetWithKeyTransformer.kt
@@ -11,27 +11,14 @@ internal class SetWithKeyTransformer<K> private constructor(
     override fun contains(element: K) =
         baseSet.contains(keyTransformer(element))
 
-    companion object {
-        fun <K> from(baseSet: Set<K>, keyTransformer: (K) -> K): SetWithKeyTransformer<K> {
-            val transformedSet = mutableSetOf<K>()
-            baseSet.forEach { key ->
-                val transformedKey = keyTransformer(key)
-                if (transformedSet.contains(transformedKey)) {
-                    throw ConflictsNotAllowed.from(key, transformedKey)
-                }
-                transformedSet.add(transformedKey)
-            }
-            return SetWithKeyTransformer(transformedSet, keyTransformer)
-        }
+    override fun toString(): String {
+        return "SetWithKeyTransformer(baseSet=$baseSet, keyTransformer=...)"
     }
 
-    class ConflictsNotAllowed(
-        keyBefore: String,
-        keyAfter: String,
-    ) : RuntimeException("Transformed key ($keyBefore -> $keyAfter) conflicts with an existing key ($keyAfter)") {
-        companion object {
-            fun <K> from(keyBefore: K, keyAfter: K) =
-                ConflictsNotAllowed(keyBefore.toString(), keyAfter.toString())
+    companion object {
+        fun <K> from(baseSet: Set<K>, keyTransformer: (K) -> K): SetWithKeyTransformer<K> {
+            val transformedSet = baseSet.map(keyTransformer).toSet()
+            return SetWithKeyTransformer(transformedSet, keyTransformer)
         }
     }
 }

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/utils/MapUtils.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/utils/MapUtils.kt
@@ -1,0 +1,16 @@
+package com.virtuslab.pulumikotlin.codegen.utils
+
+@Suppress("UnsafeCallOnNullableType")
+fun <K, V> Map<K, V?>.filterNotNullValues() =
+    this
+        .mapNotNull { (key, value) ->
+            value?.let { key to value }
+        }
+        .toMap()
+
+fun <K, V> Grouping<K, V>.valuesToSet() =
+    valuesToSet { it }
+
+fun <K, V, R> Grouping<V, K>.valuesToSet(valueSelector: (V) -> R): Map<K, Set<R>> {
+    return fold(emptySet()) { acc, v -> acc + valueSelector(v) }
+}

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/utils/StringUtils.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/utils/StringUtils.kt
@@ -1,0 +1,30 @@
+package com.virtuslab.pulumikotlin.codegen.utils
+
+import java.util.Locale
+
+fun String.capitalize() =
+    replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+
+fun String.decapitalize() =
+    replaceFirstChar { it.lowercase(Locale.getDefault()) }
+
+/**
+ * Example:
+ * ```kt
+ * "very very very very long string".shorten(20, "....") // "very ver....g string"
+ * ```
+ */
+fun String.shorten(desiredLength: Int = 20, fillWith: String = "<<shortened>>"): String {
+    if (desiredLength <= fillWith.length || desiredLength >= length) {
+        return this
+    }
+
+    val contentDesiredLength = desiredLength - fillWith.length
+    val leftSideLength = contentDesiredLength / 2
+    val rightSideLength = contentDesiredLength - leftSideLength
+
+    val left = substring(0, leftSideLength)
+    val right = substring(length - rightSideLength)
+
+    return left + fillWith + right
+}

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/utils/Utils.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/utils/Utils.kt
@@ -1,7 +1,5 @@
 package com.virtuslab.pulumikotlin.codegen.utils
 
-import java.util.Locale
-
 fun <T> T.letIf(predicate: (T) -> Boolean, mapper: (T) -> T) =
     if (predicate(this)) {
         mapper(this)
@@ -12,22 +10,10 @@ fun <T> T.letIf(predicate: (T) -> Boolean, mapper: (T) -> T) =
 fun <T> T.letIf(predicate: Boolean, mapper: (T) -> T) =
     letIf({ predicate }, mapper)
 
-fun String.capitalize() =
-    replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+fun Long.isOdd() = this % 2L != 0L
 
-fun String.decapitalize() =
-    replaceFirstChar { it.lowercase(Locale.getDefault()) }
+fun Long.isEven() = !isOdd()
 
-@Suppress("UnsafeCallOnNullableType")
-fun <K, V> Map<K, V?>.filterNotNullValues() =
-    this
-        .filter { it.value != null }
-        .map { (key, value) -> key to value!! }
-        .toMap()
+fun Int.isOdd() = toLong().isOdd()
 
-fun <K, V> Grouping<K, V>.valuesToSet() =
-    valuesToSet { it }
-
-fun <K, V, R> Grouping<V, K>.valuesToSet(valueSelector: (V) -> R): Map<K, Set<R>> {
-    return fold(emptySet()) { acc, v -> acc + valueSelector(v) }
-}
+fun Int.isEven() = !isOdd()

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/TestUtils.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/TestUtils.kt
@@ -2,6 +2,7 @@ package com.virtuslab.pulumikotlin
 
 import com.pulumi.core.Output
 import com.virtuslab.pulumikotlin.codegen.step2intermediate.PulumiNamingConfiguration
+import org.junit.jupiter.api.Assertions.assertFalse
 
 internal fun <T> extractOutputValue(output: Output<T>?): T? {
     var value: T? = null
@@ -17,3 +18,15 @@ internal fun <T> concat(vararg iterables: Iterable<T>?): List<T> =
 
 internal fun namingConfigurationWithSlashInModuleFormat(providerName: String) =
     PulumiNamingConfiguration.create(providerName = providerName, moduleFormat = "(.*)(?:/[^/]*)")
+
+private fun messagePrefix(message: String?) = if (message == null) "" else "$message. "
+
+internal fun <T> assertDoesNotContain(iterable: Iterable<T>, element: T, message: String? = null) {
+    val prefix = messagePrefix(message)
+    assertFalse(iterable.contains(element)) {
+        """
+            $prefix Expected the collection to not contain the element.
+            Collection <$iterable>, element <$element>.
+        """.trimIndent()
+    }
+}

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/CodegenTest.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/CodegenTest.kt
@@ -455,6 +455,11 @@ class CodegenTest {
         assertGeneratedCodeAndSourceFileCompile(SCHEMA_AWS_CLASSIC_SUBSET_WITH_ASSET, code)
     }
 
+    @Test
+    fun `IpAllocationMethod (azure-native) should work despite being defined two times (with different casing)`() {
+        assertGeneratedCodeCompiles(SCHEMA_AZURE_NATIVE_SUBSET_WITH_IP_ALLOCATION)
+    }
+
     private fun assertGeneratedCodeCompiles(schemaPath: String) {
         assertGeneratedCodeAndSourceFilesCompile(schemaPath, emptyMap())
     }
@@ -589,3 +594,5 @@ private const val SCHEMA_AWS_CLASSIC_SUBSET_WITH_ARCHIVE = "schema-aws-classic-5
 private const val SCHEMA_AWS_CLASSIC_SUBSET_WITH_ASSET = "schema-aws-classic-5.16.2-subset-with-asset.json"
 private const val SCHEMA_AWS_CLASSIC_SUBSET_WITH_INDEX = "schema-aws-classic-5.15.2-subset-with-index.json"
 private const val SCHEMA_SLACK_SUBSET_WITH_INDEX = "schema-slack-0.3.0-subset-with-index.json"
+private const val SCHEMA_AZURE_NATIVE_SUBSET_WITH_IP_ALLOCATION =
+    "schema-azure-native-3.44.2-subset-with-ip-allocation.json"

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/MapWithKeyTransformerTest.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/MapWithKeyTransformerTest.kt
@@ -1,10 +1,12 @@
 package com.virtuslab.pulumikotlin.codegen.step2intermediate
 
 import com.virtuslab.pulumikotlin.codegen.step2intermediate.MapWithKeyTransformer.ConflictsNotAllowed
+import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertSame
 
 internal class MapWithKeyTransformerTest {
     @Test
@@ -13,10 +15,12 @@ internal class MapWithKeyTransformerTest {
 
         val transformedMap = baseMap.lowercaseKeys()
 
-        assertEquals("B", transformedMap["a"])
-        assertEquals("B", transformedMap["A"])
-        assertEquals("c", transformedMap["b"])
-        assertEquals("c", transformedMap["B"])
+        assertAll(
+            { assertEquals("B", transformedMap["a"]) },
+            { assertEquals("B", transformedMap["A"]) },
+            { assertEquals("c", transformedMap["b"]) },
+            { assertEquals("c", transformedMap["B"]) },
+        )
     }
 
     @Test
@@ -25,18 +29,47 @@ internal class MapWithKeyTransformerTest {
 
         val transformedMap = baseMap.transformKeys { it.copy(first = it.first.lowercase()) }
 
-        assertEquals("B", transformedMap[Pair("A", "B")])
-        assertEquals("B", transformedMap[Pair("a", "B")])
-        assertNull(transformedMap[Pair("a", "b")])
-        assertNull(transformedMap[Pair("A", "b")])
+        assertAll(
+            { assertEquals("B", transformedMap[Pair("A", "B")]) },
+            { assertEquals("B", transformedMap[Pair("a", "B")]) },
+            { assertNull(transformedMap[Pair("a", "b")]) },
+            { assertNull(transformedMap[Pair("A", "b")]) },
+        )
     }
 
     @Test
-    fun `lowercaseKeys should not allow mapping to identical keys (conflicts)`() {
+    fun `lowercaseKeys should not allow mapping to identical keys if values differ (conflicts)`() {
         val baseMap = mapOf("a" to "B", "A" to "c")
 
         assertThrows<ConflictsNotAllowed> {
             baseMap.lowercaseKeys()
         }
+    }
+
+    @Test
+    fun `lowercaseKeys should allow mapping to identical keys if values are the same (references)`() {
+        class A
+        val value1 = A()
+
+        val baseMap = mapOf("a" to value1, "A" to value1)
+
+        val transformedMap = baseMap.lowercaseKeys()
+
+        assertAll(
+            { assertSame(value1, transformedMap["a"]) },
+            { assertSame(value1, transformedMap["A"]) },
+        )
+    }
+
+    @Test
+    fun `lowercaseKeys should allow mapping to identical keys if values are the same (structural equality)`() {
+        val baseMap = mapOf("a" to "B", "A" to "B")
+
+        val transformedMap = baseMap.lowercaseKeys()
+
+        assertAll(
+            { assertEquals("B", transformedMap["a"]) },
+            { assertEquals("B", transformedMap["A"]) },
+        )
     }
 }

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/SetWithKeyTransformerTest.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/SetWithKeyTransformerTest.kt
@@ -1,10 +1,9 @@
 package com.virtuslab.pulumikotlin.codegen.step2intermediate
 
-import com.virtuslab.pulumikotlin.codegen.step2intermediate.SetWithKeyTransformer.ConflictsNotAllowed
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.virtuslab.pulumikotlin.assertDoesNotContain
+import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertContains
 
 internal class SetWithKeyTransformerTest {
     @Test
@@ -13,29 +12,36 @@ internal class SetWithKeyTransformerTest {
 
         val transformedSet = baseSet.transformKeys { it.lowercase() }
 
-        assertTrue(transformedSet.contains("A"))
-        assertTrue(transformedSet.contains("a"))
+        assertAll(
+            { assertContains(transformedSet, "a") },
+            { assertContains(transformedSet, "A") },
+        )
     }
 
     @Test
-    fun `lowercaseKeys works for Pair key`() {
+    fun `transformKeys works for Pair key`() {
         val baseSet = setOf(Pair("a", "B")) + anyPairSet()
 
         val transformedSet = baseSet.transformKeys { it.copy(first = it.first.lowercase()) }
 
-        assertTrue(transformedSet.contains(Pair("a", "B")))
-        assertTrue(transformedSet.contains(Pair("A", "B")))
-        assertFalse(transformedSet.contains(Pair("A", "b")))
-        assertFalse(transformedSet.contains(Pair("a", "b")))
+        assertAll(
+            { assertContains(transformedSet, Pair("a", "B")) },
+            { assertContains(transformedSet, Pair("A", "B")) },
+            { assertDoesNotContain(transformedSet, Pair("A", "b")) },
+            { assertDoesNotContain(transformedSet, Pair("a", "b")) },
+        )
     }
 
     @Test
-    fun `lowercaseKeys should not allow mapping to identical keys (conflicts)`() {
-        val baseSet = setOf("a", "A") + anyStringSet()
+    fun `transformKeys should allow mapping to identical keys`() {
+        val baseSet = setOf("a", "A", "a") + anyStringSet()
 
-        assertThrows<ConflictsNotAllowed> {
-            baseSet.transformKeys { it.lowercase() }
-        }
+        val transformedSet = baseSet.transformKeys { it.lowercase() }
+
+        assertAll(
+            { assertContains(transformedSet, "a") },
+            { assertContains(transformedSet, "A") },
+        )
     }
 
     private fun anyPairSet() =

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/utils/MapUtilsKtTest.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/utils/MapUtilsKtTest.kt
@@ -1,0 +1,36 @@
+package com.virtuslab.pulumikotlin.codegen.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class MapUtilsKtTest {
+    @Test
+    fun `filterNotNullValues removes null values from any Map`() {
+        val mapWithNullValues = mapOf("a" to null, "b" to "c")
+
+        val mapAfterFiltering = mapWithNullValues.filterNotNullValues()
+
+        assertEquals(mapOf("b" to "c"), mapAfterFiltering)
+    }
+
+    @Test
+    fun `valuesToSet takes any Grouping and creates Map (where values are of type Set) `() {
+        val list = listOf(
+            "a" to 1,
+            "a" to 2,
+            "b" to 1,
+            "c" to 1,
+            "c" to 1,
+        )
+
+        val mapAfterGrouping = list
+            .groupingBy { it.second }
+            .valuesToSet { it.first }
+
+        val expectedMap = mapOf(
+            1 to setOf("a", "b", "c"),
+            2 to setOf("a"),
+        )
+        assertEquals(expectedMap, mapAfterGrouping)
+    }
+}

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/utils/StringUtilsKtTest.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/utils/StringUtilsKtTest.kt
@@ -1,0 +1,78 @@
+package com.virtuslab.pulumikotlin.codegen.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+internal class StringUtilsKtTest {
+    @Test
+    fun `capitalize should change the first letter`() {
+        assertEquals("Word", "word".capitalize())
+    }
+
+    @Test
+    fun `capitalize should be ok if the string is already capitalized`() {
+        assertEquals("Word", "Word".capitalize())
+    }
+
+    @Test
+    fun `decapitalize should change the first letter`() {
+        assertEquals("word", "Word".decapitalize())
+    }
+
+    @Test
+    fun `decapitalize should be ok if the string is already decapitalized`() {
+        assertEquals("word", "Word".decapitalize())
+    }
+
+    @Suppress("unused")
+    enum class ShortenTestCase(
+        val inputString: String,
+        val desiredLength: Int,
+        val fillWith: String,
+        val expectedString: String,
+    ) {
+        ShortenExampleFromKDoc(
+            inputString = "very very very very long string",
+            desiredLength = 20,
+            fillWith = "....",
+            expectedString = "very ver....g string",
+        ),
+        ShortenOddStringLengthEvenDesiredLength(
+            inputString = "too long string with odd length".also { assumeTrue(it.length.isOdd()) },
+            desiredLength = 22,
+            fillWith = "***",
+            expectedString = "too long ***odd length",
+        ),
+        ShortenEvenStringLengthEvenDesiredLength(
+            inputString = "too long string with even length".also { assumeTrue(it.length.isEven()) },
+            desiredLength = 22,
+            fillWith = "---",
+            expectedString = "too long ---ven length",
+        ),
+        ShortenOddStringLengthOddDesiredLength(
+            inputString = "too long string with odd length".also { assumeTrue(it.length.isOdd()) },
+            desiredLength = 23,
+            fillWith = "===",
+            expectedString = "too long s===odd length",
+        ),
+        ShortenEvenStringLengthOddDesiredLength(
+            inputString = "too long string with even length".also { assumeTrue(it.length.isEven()) },
+            desiredLength = 23,
+            fillWith = "###",
+            expectedString = "too long s###ven length",
+        ),
+    }
+
+    @EnumSource(ShortenTestCase::class)
+    @ParameterizedTest
+    fun `shorten should work`(testCase: ShortenTestCase) {
+        // when
+        val shortened = testCase.inputString.shorten(testCase.desiredLength, testCase.fillWith)
+
+        // then
+        assertEquals(testCase.expectedString, shortened)
+    }
+}

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/utils/UtilsKtTest.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/utils/UtilsKtTest.kt
@@ -5,26 +5,6 @@ import org.junit.jupiter.api.Test
 
 internal class UtilsKtTest {
     @Test
-    fun `capitalize should change the first letter`() {
-        assertEquals("Word", "word".capitalize())
-    }
-
-    @Test
-    fun `capitalize should be ok if the string is already capitalized`() {
-        assertEquals("Word", "Word".capitalize())
-    }
-
-    @Test
-    fun `decapitalize should change the first letter`() {
-        assertEquals("word", "Word".decapitalize())
-    }
-
-    @Test
-    fun `decapitalize should be ok if the string is already decapitalized`() {
-        assertEquals("word", "Word".decapitalize())
-    }
-
-    @Test
     fun `letIf should invoke the mapper if its first argument is set to true`() {
         val result = StringBuilder()
             .append("letIf")
@@ -46,35 +26,5 @@ internal class UtilsKtTest {
             .toString()
 
         assertEquals("letIf works!", result)
-    }
-
-    @Test
-    fun `filterNotNullValues removes null values from any Map`() {
-        val mapWithNullValues = mapOf("a" to null, "b" to "c")
-
-        val mapAfterFiltering = mapWithNullValues.filterNotNullValues()
-
-        assertEquals(mapOf("b" to "c"), mapAfterFiltering)
-    }
-
-    @Test
-    fun `valuesToSet takes any Grouping and creates Map (where values are of type Set) `() {
-        val list = listOf(
-            "a" to 1,
-            "a" to 2,
-            "b" to 1,
-            "c" to 1,
-            "c" to 1,
-        )
-
-        val mapAfterGrouping = list
-            .groupingBy { it.second }
-            .valuesToSet { it.first }
-
-        val expectedMap = mapOf(
-            1 to setOf("a", "b", "c"),
-            2 to setOf("a"),
-        )
-        assertEquals(expectedMap, mapAfterGrouping)
     }
 }

--- a/src/test/resources/schema-aws-classic-5.16.2-subset-for-compute-schema-subset-script-test.json
+++ b/src/test/resources/schema-aws-classic-5.16.2-subset-for-compute-schema-subset-script-test.json
@@ -33,56 +33,11 @@
         "values"
       ]
     },
-    "aws:accessanalyzer/ArchiveRuleFilter:ArchiveRuleFilter": {
+    "aws:lambda/FunctionDeadLetterConfig:FunctionDeadLetterConfig": {
       "properties": {
-        "contains": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Contains comparator.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "criteria": {
+        "targetArn": {
           "type": "string",
-          "description": "Filter criteria.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "eqs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Equals comparator.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "exists": {
-          "type": "string",
-          "description": "Boolean comparator.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "neqs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Not Equals comparator.\n",
+          "description": "ARN of an SNS topic or SQS queue to notify <<shortened>>RN, depending on which service is targeted.\n",
           "language": {
             "python": {
               "mapCase": false
@@ -92,16 +47,175 @@
       },
       "type": "object",
       "required": [
-        "criteria"
+        "targetArn"
+      ]
+    },
+    "aws:lambda/FunctionEnvironment:FunctionEnvironment": {
+      "properties": {
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of environment variables that are accessible from the function code during execution.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:lambda/FunctionEphemeralStorage:FunctionEphemeralStorage": {
+      "properties": {
+        "size": {
+          "type": "integer",
+          "description": "The size of the Lambda function Ephemeral s<<shortened>>d the maximum supported value is `10240`MB.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "language": {
+        "nodejs": {
+          "requiredOutputs": [
+            "size"
+          ]
+        }
+      }
+    },
+    "aws:lambda/FunctionFileSystemConfig:FunctionFileSystemConfig": {
+      "properties": {
+        "arn": {
+          "type": "string",
+          "description": "Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "localMountPath": {
+          "type": "string",
+          "description": "Path where the function can access the file system, starting with /mnt/.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "arn",
+        "localMountPath"
+      ]
+    },
+    "aws:lambda/FunctionImageConfig:FunctionImageConfig": {
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Parameters that you want to pass in with `entry_point`.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "entryPoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Entry point to your application, which is typically the location of the runtime executable.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "workingDirectory": {
+          "type": "string",
+          "description": "Working directory.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:lambda/FunctionTracingConfig:FunctionTracingConfig": {
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "Whether to to sample and trace a subset of <<shortened>>bda will call X-Ray for a tracing decision.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "mode"
+      ]
+    },
+    "aws:lambda/FunctionVpcConfig:FunctionVpcConfig": {
+      "properties": {
+        "securityGroupIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of security group IDs associated with the Lambda function.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "subnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of subnet IDs associated with the Lambda function.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "vpcId": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "securityGroupIds",
+        "subnetIds"
       ],
       "language": {
         "nodejs": {
           "requiredOutputs": [
-            "contains",
-            "criteria",
-            "eqs",
-            "exists",
-            "neqs"
+            "securityGroupIds",
+            "subnetIds",
+            "vpcId"
           ]
         }
       }
@@ -195,277 +309,18 @@
           "value": "provided.al2"
         }
       ]
-    },
-    "aws:lambda/FunctionDeadLetterConfig:FunctionDeadLetterConfig": {
-      "properties": {
-        "targetArn": {
-          "type": "string",
-          "description": "ARN of an SNS topic or SQS queue to notify when an invocation fails. If this option is used, the function's IAM role must be granted suitable access to write to the target object, which means allowing either the `sns:Publish` or `sqs:SendMessage` action on this ARN, depending on which service is targeted.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        }
-      },
-      "type": "object",
-      "required": [
-        "targetArn"
-      ]
-    },
-    "aws:lambda/FunctionEnvironment:FunctionEnvironment": {
-      "properties": {
-        "variables": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Map of environment variables that are accessible from the function code during execution.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        }
-      },
-      "type": "object"
-    },
-    "aws:lambda/FunctionEphemeralStorage:FunctionEphemeralStorage": {
-      "properties": {
-        "size": {
-          "type": "integer",
-          "description": "The size of the Lambda function Ephemeral storage(`/tmp`) represented in MB. The minimum supported `ephemeral_storage` value defaults to `512`MB and the maximum supported value is `10240`MB.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        }
-      },
-      "type": "object",
-      "language": {
-        "nodejs": {
-          "requiredOutputs": [
-            "size"
-          ]
-        }
-      }
-    },
-    "aws:lambda/FunctionFileSystemConfig:FunctionFileSystemConfig": {
-      "properties": {
-        "arn": {
-          "type": "string",
-          "description": "Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "localMountPath": {
-          "type": "string",
-          "description": "Path where the function can access the file system, starting with /mnt/.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        }
-      },
-      "type": "object",
-      "required": [
-        "arn",
-        "localMountPath"
-      ]
-    },
-    "aws:lambda/FunctionImageConfig:FunctionImageConfig": {
-      "properties": {
-        "commands": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Parameters that you want to pass in with `entry_point`.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "entryPoints": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Entry point to your application, which is typically the location of the runtime executable.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "workingDirectory": {
-          "type": "string",
-          "description": "Working directory.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        }
-      },
-      "type": "object"
-    },
-    "aws:lambda/FunctionTracingConfig:FunctionTracingConfig": {
-      "properties": {
-        "mode": {
-          "type": "string",
-          "description": "Whether to to sample and trace a subset of incoming requests with AWS X-Ray. Valid values are `PassThrough` and `Active`. If `PassThrough`, Lambda will only trace the request from an upstream service if it contains a tracing header with \"sampled=1\". If `Active`, Lambda will respect any tracing header it receives from an upstream service. If no tracing header is received, Lambda will call X-Ray for a tracing decision.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        }
-      },
-      "type": "object",
-      "required": [
-        "mode"
-      ]
-    },
-    "aws:lambda/FunctionVpcConfig:FunctionVpcConfig": {
-      "properties": {
-        "securityGroupIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "List of security group IDs associated with the Lambda function.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "subnetIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "List of subnet IDs associated with the Lambda function.\n",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        },
-        "vpcId": {
-          "type": "string",
-          "language": {
-            "python": {
-              "mapCase": false
-            }
-          }
-        }
-      },
-      "type": "object",
-      "required": [
-        "securityGroupIds",
-        "subnetIds"
-      ],
-      "language": {
-        "nodejs": {
-          "requiredOutputs": [
-            "securityGroupIds",
-            "subnetIds",
-            "vpcId"
-          ]
-        }
-      }
     }
   },
   "resources": {
-    "aws:accessanalyzer/archiveRule:ArchiveRule": {
-      "description": "{{% examples %}}\n## Example Usage\n{{% example %}}\n### Basic Usage\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\n\nconst example = new aws.accessanalyzer.ArchiveRule(\"example\", {\n    analyzerName: \"example-analyzer\",\n    filters: [\n        {\n            criteria: \"condition.aws:UserId\",\n            eqs: [\"userid\"],\n        },\n        {\n            criteria: \"error\",\n            exists: \"true\",\n        },\n        {\n            criteria: \"isPublic\",\n            eqs: [\"false\"],\n        },\n    ],\n    ruleName: \"example-rule\",\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\n\nexample = aws.accessanalyzer.ArchiveRule(\"example\",\n    analyzer_name=\"example-analyzer\",\n    filters=[\n        aws.accessanalyzer.ArchiveRuleFilterArgs(\n            criteria=\"condition.aws:UserId\",\n            eqs=[\"userid\"],\n        ),\n        aws.accessanalyzer.ArchiveRuleFilterArgs(\n            criteria=\"error\",\n            exists=\"true\",\n        ),\n        aws.accessanalyzer.ArchiveRuleFilterArgs(\n            criteria=\"isPublic\",\n            eqs=[\"false\"],\n        ),\n    ],\n    rule_name=\"example-rule\")\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\n\nreturn await Deployment.RunAsync(() => \n{\n    var example = new Aws.AccessAnalyzer.ArchiveRule(\"example\", new()\n    {\n        AnalyzerName = \"example-analyzer\",\n        Filters = new[]\n        {\n            new Aws.AccessAnalyzer.Inputs.ArchiveRuleFilterArgs\n            {\n                Criteria = \"condition.aws:UserId\",\n                Eqs = new[]\n                {\n                    \"userid\",\n                },\n            },\n            new Aws.AccessAnalyzer.Inputs.ArchiveRuleFilterArgs\n            {\n                Criteria = \"error\",\n                Exists = \"true\",\n            },\n            new Aws.AccessAnalyzer.Inputs.ArchiveRuleFilterArgs\n            {\n                Criteria = \"isPublic\",\n                Eqs = new[]\n                {\n                    \"false\",\n                },\n            },\n        },\n        RuleName = \"example-rule\",\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/accessanalyzer\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\t_, err := accessanalyzer.NewArchiveRule(ctx, \"example\", &accessanalyzer.ArchiveRuleArgs{\n\t\t\tAnalyzerName: pulumi.String(\"example-analyzer\"),\n\t\t\tFilters: accessanalyzer.ArchiveRuleFilterArray{\n\t\t\t\t&accessanalyzer.ArchiveRuleFilterArgs{\n\t\t\t\t\tCriteria: pulumi.String(\"condition.aws:UserId\"),\n\t\t\t\t\tEqs: pulumi.StringArray{\n\t\t\t\t\t\tpulumi.String(\"userid\"),\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t\t&accessanalyzer.ArchiveRuleFilterArgs{\n\t\t\t\t\tCriteria: pulumi.String(\"error\"),\n\t\t\t\t\tExists:   pulumi.String(\"true\"),\n\t\t\t\t},\n\t\t\t\t&accessanalyzer.ArchiveRuleFilterArgs{\n\t\t\t\t\tCriteria: pulumi.String(\"isPublic\"),\n\t\t\t\t\tEqs: pulumi.StringArray{\n\t\t\t\t\t\tpulumi.String(\"false\"),\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t\tRuleName: pulumi.String(\"example-rule\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.aws.accessanalyzer.ArchiveRule;\nimport com.pulumi.aws.accessanalyzer.ArchiveRuleArgs;\nimport com.pulumi.aws.accessanalyzer.inputs.ArchiveRuleFilterArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var example = new ArchiveRule(\"example\", ArchiveRuleArgs.builder()        \n            .analyzerName(\"example-analyzer\")\n            .filters(            \n                ArchiveRuleFilterArgs.builder()\n                    .criteria(\"condition.aws:UserId\")\n                    .eqs(\"userid\")\n                    .build(),\n                ArchiveRuleFilterArgs.builder()\n                    .criteria(\"error\")\n                    .exists(true)\n                    .build(),\n                ArchiveRuleFilterArgs.builder()\n                    .criteria(\"isPublic\")\n                    .eqs(\"false\")\n                    .build())\n            .ruleName(\"example-rule\")\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  example:\n    type: aws:accessanalyzer:ArchiveRule\n    properties:\n      analyzerName: example-analyzer\n      filters:\n        - criteria: condition.aws:UserId\n          eqs:\n            - userid\n        - criteria: error\n          exists: true\n        - criteria: isPublic\n          eqs:\n            - false\n      ruleName: example-rule\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nAccessAnalyzer ArchiveRule can be imported using the `analyzer_name/rule_name`, e.g.,\n\n```sh\n $ pulumi import aws:accessanalyzer/archiveRule:ArchiveRule example example-analyzer/example-rule\n```\n\n ",
-      "properties": {
-        "analyzerName": {
-          "type": "string",
-          "description": "Analyzer name.\n"
-        },
-        "filters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/types/aws:accessanalyzer/ArchiveRuleFilter:ArchiveRuleFilter"
-          },
-          "description": "Filter criteria for the archive rule. See Filter for more details.\n"
-        },
-        "ruleName": {
-          "type": "string",
-          "description": "Rule name.\n"
-        }
-      },
-      "required": [
-        "analyzerName",
-        "filters",
-        "ruleName"
-      ],
-      "inputProperties": {
-        "analyzerName": {
-          "type": "string",
-          "description": "Analyzer name.\n",
-          "willReplaceOnChanges": true
-        },
-        "filters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/types/aws:accessanalyzer/ArchiveRuleFilter:ArchiveRuleFilter"
-          },
-          "description": "Filter criteria for the archive rule. See Filter for more details.\n"
-        },
-        "ruleName": {
-          "type": "string",
-          "description": "Rule name.\n",
-          "willReplaceOnChanges": true
-        }
-      },
-      "requiredInputs": [
-        "analyzerName",
-        "filters",
-        "ruleName"
-      ],
-      "stateInputs": {
-        "description": "Input properties used for looking up and filtering ArchiveRule resources.\n",
-        "properties": {
-          "analyzerName": {
-            "type": "string",
-            "description": "Analyzer name.\n",
-            "willReplaceOnChanges": true
-          },
-          "filters": {
-            "type": "array",
-            "items": {
-              "$ref": "#/types/aws:accessanalyzer/ArchiveRuleFilter:ArchiveRuleFilter"
-            },
-            "description": "Filter criteria for the archive rule. See Filter for more details.\n"
-          },
-          "ruleName": {
-            "type": "string",
-            "description": "Rule name.\n",
-            "willReplaceOnChanges": true
-          }
-        },
-        "type": "object"
-      }
-    },
     "aws:lambda/function:Function": {
-      "description": "Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS, enabling serverless backend solutions. The Lambda Function itself includes source code and runtime configuration.\n\nFor information about Lambda and how to use it, see [What is AWS Lambda?](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html)\n\n> To give an external source (like a CloudWatch Event Rule, SNS, or S3) permission to access the Lambda function, use the `aws.lambda.Permission` resource. See [Lambda ****Permission Model][4] for more details. On the other hand, the `role` argument of this resource is the function's execution role for identity and access to AWS services and resources.\n\n> **NOTE:** Due to [AWS Lambda improved VPC networking changes that began deploying in September 2019](https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/), EC2 subnets and security groups associated with Lambda Functions can take up to 45 minutes to successfully delete.\n\n> To give an external source (like an EventBridge Rule, SNS, or S3) permission to access the Lambda function, use the `aws.lambda.Permission` resource. See [Lambda Permission Model](https://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html) for more details. On the other hand, the `role` argument of this resource is the function's execution role for identity and access to AWS services and resources.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n### Basic Example\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\n\nconst iamForLambda = new aws.iam.Role(\"iamForLambda\", {assumeRolePolicy: `{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n`});\nconst testLambda = new aws.lambda.Function(\"testLambda\", {\n    code: new pulumi.asset.FileArchive(\"lambda_function_payload.zip\"),\n    role: iamForLambda.arn,\n    handler: \"index.test\",\n    runtime: \"nodejs12.x\",\n    environment: {\n        variables: {\n            foo: \"bar\",\n        },\n    },\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\n\niam_for_lambda = aws.iam.Role(\"iamForLambda\", assume_role_policy=\"\"\"{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n\"\"\")\ntest_lambda = aws.lambda_.Function(\"testLambda\",\n    code=pulumi.FileArchive(\"lambda_function_payload.zip\"),\n    role=iam_for_lambda.arn,\n    handler=\"index.test\",\n    runtime=\"nodejs12.x\",\n    environment=aws.lambda_.FunctionEnvironmentArgs(\n        variables={\n            \"foo\": \"bar\",\n        },\n    ))\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\n\nreturn await Deployment.RunAsync(() => \n{\n    var iamForLambda = new Aws.Iam.Role(\"iamForLambda\", new()\n    {\n        AssumeRolePolicy = @\"{\n  \"\"Version\"\": \"\"2012-10-17\"\",\n  \"\"Statement\"\": [\n    {\n      \"\"Action\"\": \"\"sts:AssumeRole\"\",\n      \"\"Principal\"\": {\n        \"\"Service\"\": \"\"lambda.amazonaws.com\"\"\n      },\n      \"\"Effect\"\": \"\"Allow\"\",\n      \"\"Sid\"\": \"\"\"\"\n    }\n  ]\n}\n\",\n    });\n\n    var testLambda = new Aws.Lambda.Function(\"testLambda\", new()\n    {\n        Code = new FileArchive(\"lambda_function_payload.zip\"),\n        Role = iamForLambda.Arn,\n        Handler = \"index.test\",\n        Runtime = \"nodejs12.x\",\n        Environment = new Aws.Lambda.Inputs.FunctionEnvironmentArgs\n        {\n            Variables = \n            {\n                { \"foo\", \"bar\" },\n            },\n        },\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lambda\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tiamForLambda, err := iam.NewRole(ctx, \"iamForLambda\", &iam.RoleArgs{\n\t\t\tAssumeRolePolicy: pulumi.Any(fmt.Sprintf(`{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n`)),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = lambda.NewFunction(ctx, \"testLambda\", &lambda.FunctionArgs{\n\t\t\tCode:    pulumi.NewFileArchive(\"lambda_function_payload.zip\"),\n\t\t\tRole:    iamForLambda.Arn,\n\t\t\tHandler: pulumi.String(\"index.test\"),\n\t\t\tRuntime: pulumi.String(\"nodejs12.x\"),\n\t\t\tEnvironment: &lambda.FunctionEnvironmentArgs{\n\t\t\t\tVariables: pulumi.StringMap{\n\t\t\t\t\t\"foo\": pulumi.String(\"bar\"),\n\t\t\t\t},\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.aws.iam.Role;\nimport com.pulumi.aws.iam.RoleArgs;\nimport com.pulumi.aws.lambda.Function;\nimport com.pulumi.aws.lambda.FunctionArgs;\nimport com.pulumi.aws.lambda.inputs.FunctionEnvironmentArgs;\nimport com.pulumi.asset.FileArchive;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var iamForLambda = new Role(\"iamForLambda\", RoleArgs.builder()        \n            .assumeRolePolicy(\"\"\"\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n            \"\"\")\n            .build());\n\n        var testLambda = new Function(\"testLambda\", FunctionArgs.builder()        \n            .code(new FileArchive(\"lambda_function_payload.zip\"))\n            .role(iamForLambda.arn())\n            .handler(\"index.test\")\n            .runtime(\"nodejs12.x\")\n            .environment(FunctionEnvironmentArgs.builder()\n                .variables(Map.of(\"foo\", \"bar\"))\n                .build())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  iamForLambda:\n    type: aws:iam:Role\n    properties:\n      assumeRolePolicy: |\n        {\n          \"Version\": \"2012-10-17\",\n          \"Statement\": [\n            {\n              \"Action\": \"sts:AssumeRole\",\n              \"Principal\": {\n                \"Service\": \"lambda.amazonaws.com\"\n              },\n              \"Effect\": \"Allow\",\n              \"Sid\": \"\"\n            }\n          ]\n        }\n  testLambda:\n    type: aws:lambda:Function\n    properties:\n      # If the file is not in the current working directory you will need to include a\n      #   # path.module in the filename.\n      code:\n        Fn::FileArchive: lambda_function_payload.zip\n      role: ${iamForLambda.arn}\n      handler: index.test\n      runtime: nodejs12.x\n      environment:\n        variables:\n          foo: bar\n```\n{{% /example %}}\n{{% example %}}\n### Lambda Layers\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\n\nconst exampleLayerVersion = new aws.lambda.LayerVersion(\"exampleLayerVersion\", {});\n// ... other configuration ...\nconst exampleFunction = new aws.lambda.Function(\"exampleFunction\", {layers: [exampleLayerVersion.arn]});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\n\nexample_layer_version = aws.lambda_.LayerVersion(\"exampleLayerVersion\")\n# ... other configuration ...\nexample_function = aws.lambda_.Function(\"exampleFunction\", layers=[example_layer_version.arn])\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\n\nreturn await Deployment.RunAsync(() => \n{\n    var exampleLayerVersion = new Aws.Lambda.LayerVersion(\"exampleLayerVersion\");\n\n    // ... other configuration ...\n    var exampleFunction = new Aws.Lambda.Function(\"exampleFunction\", new()\n    {\n        Layers = new[]\n        {\n            exampleLayerVersion.Arn,\n        },\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lambda\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\texampleLayerVersion, err := lambda.NewLayerVersion(ctx, \"exampleLayerVersion\", nil)\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = lambda.NewFunction(ctx, \"exampleFunction\", &lambda.FunctionArgs{\n\t\t\tLayers: pulumi.StringArray{\n\t\t\t\texampleLayerVersion.Arn,\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.aws.lambda.LayerVersion;\nimport com.pulumi.aws.lambda.Function;\nimport com.pulumi.aws.lambda.FunctionArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var exampleLayerVersion = new LayerVersion(\"exampleLayerVersion\");\n\n        var exampleFunction = new Function(\"exampleFunction\", FunctionArgs.builder()        \n            .layers(exampleLayerVersion.arn())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  exampleLayerVersion:\n    type: aws:lambda:LayerVersion\n  exampleFunction:\n    type: aws:lambda:Function\n    properties:\n      # ... other configuration ...\n      layers:\n        - ${exampleLayerVersion.arn}\n```\n{{% /example %}}\n{{% example %}}\n### Lambda Ephemeral Storage\n\nLambda Function Ephemeral Storage(`/tmp`) allows you to configure the storage upto `10` GB. The default value set to `512` MB.\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\n\nconst iamForLambda = new aws.iam.Role(\"iamForLambda\", {assumeRolePolicy: `{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n`});\nconst testLambda = new aws.lambda.Function(\"testLambda\", {\n    code: new pulumi.asset.FileArchive(\"lambda_function_payload.zip\"),\n    role: iamForLambda.arn,\n    handler: \"index.test\",\n    runtime: \"nodejs14.x\",\n    ephemeralStorage: {\n        size: 10240,\n    },\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\n\niam_for_lambda = aws.iam.Role(\"iamForLambda\", assume_role_policy=\"\"\"{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n\"\"\")\ntest_lambda = aws.lambda_.Function(\"testLambda\",\n    code=pulumi.FileArchive(\"lambda_function_payload.zip\"),\n    role=iam_for_lambda.arn,\n    handler=\"index.test\",\n    runtime=\"nodejs14.x\",\n    ephemeral_storage=aws.lambda_.FunctionEphemeralStorageArgs(\n        size=10240,\n    ))\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\n\nreturn await Deployment.RunAsync(() => \n{\n    var iamForLambda = new Aws.Iam.Role(\"iamForLambda\", new()\n    {\n        AssumeRolePolicy = @\"{\n  \"\"Version\"\": \"\"2012-10-17\"\",\n  \"\"Statement\"\": [\n    {\n      \"\"Action\"\": \"\"sts:AssumeRole\"\",\n      \"\"Principal\"\": {\n        \"\"Service\"\": \"\"lambda.amazonaws.com\"\"\n      },\n      \"\"Effect\"\": \"\"Allow\"\",\n      \"\"Sid\"\": \"\"\"\"\n    }\n  ]\n}\n\",\n    });\n\n    var testLambda = new Aws.Lambda.Function(\"testLambda\", new()\n    {\n        Code = new FileArchive(\"lambda_function_payload.zip\"),\n        Role = iamForLambda.Arn,\n        Handler = \"index.test\",\n        Runtime = \"nodejs14.x\",\n        EphemeralStorage = new Aws.Lambda.Inputs.FunctionEphemeralStorageArgs\n        {\n            Size = 10240,\n        },\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lambda\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tiamForLambda, err := iam.NewRole(ctx, \"iamForLambda\", &iam.RoleArgs{\n\t\t\tAssumeRolePolicy: pulumi.Any(fmt.Sprintf(`{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n`)),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = lambda.NewFunction(ctx, \"testLambda\", &lambda.FunctionArgs{\n\t\t\tCode:    pulumi.NewFileArchive(\"lambda_function_payload.zip\"),\n\t\t\tRole:    iamForLambda.Arn,\n\t\t\tHandler: pulumi.String(\"index.test\"),\n\t\t\tRuntime: pulumi.String(\"nodejs14.x\"),\n\t\t\tEphemeralStorage: &lambda.FunctionEphemeralStorageArgs{\n\t\t\t\tSize: pulumi.Int(10240),\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.aws.iam.Role;\nimport com.pulumi.aws.iam.RoleArgs;\nimport com.pulumi.aws.lambda.Function;\nimport com.pulumi.aws.lambda.FunctionArgs;\nimport com.pulumi.aws.lambda.inputs.FunctionEphemeralStorageArgs;\nimport com.pulumi.asset.FileArchive;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var iamForLambda = new Role(\"iamForLambda\", RoleArgs.builder()        \n            .assumeRolePolicy(\"\"\"\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n            \"\"\")\n            .build());\n\n        var testLambda = new Function(\"testLambda\", FunctionArgs.builder()        \n            .code(new FileArchive(\"lambda_function_payload.zip\"))\n            .role(iamForLambda.arn())\n            .handler(\"index.test\")\n            .runtime(\"nodejs14.x\")\n            .ephemeralStorage(FunctionEphemeralStorageArgs.builder()\n                .size(10240)\n                .build())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  iamForLambda:\n    type: aws:iam:Role\n    properties:\n      assumeRolePolicy: |\n        {\n          \"Version\": \"2012-10-17\",\n          \"Statement\": [\n            {\n              \"Action\": \"sts:AssumeRole\",\n              \"Principal\": {\n                \"Service\": \"lambda.amazonaws.com\"\n              },\n              \"Effect\": \"Allow\",\n              \"Sid\": \"\"\n            }\n          ]\n        }\n  testLambda:\n    type: aws:lambda:Function\n    properties:\n      code:\n        Fn::FileArchive: lambda_function_payload.zip\n      role: ${iamForLambda.arn}\n      handler: index.test\n      runtime: nodejs14.x\n      ephemeralStorage:\n        size: 10240\n```\n{{% /example %}}\n{{% example %}}\n### Lambda File Systems\n\nLambda File Systems allow you to connect an Amazon Elastic File System (EFS) file system to a Lambda function to share data across function invocations, access existing data including large files, and save function state.\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\n\n// EFS file system\nconst efsForLambda = new aws.efs.FileSystem(\"efsForLambda\", {tags: {\n    Name: \"efs_for_lambda\",\n}});\n// Mount target connects the file system to the subnet\nconst alpha = new aws.efs.MountTarget(\"alpha\", {\n    fileSystemId: efsForLambda.id,\n    subnetId: aws_subnet.subnet_for_lambda.id,\n    securityGroups: [aws_security_group.sg_for_lambda.id],\n});\n// EFS access point used by lambda file system\nconst accessPointForLambda = new aws.efs.AccessPoint(\"accessPointForLambda\", {\n    fileSystemId: efsForLambda.id,\n    rootDirectory: {\n        path: \"/lambda\",\n        creationInfo: {\n            ownerGid: 1000,\n            ownerUid: 1000,\n            permissions: \"777\",\n        },\n    },\n    posixUser: {\n        gid: 1000,\n        uid: 1000,\n    },\n});\n// A lambda function connected to an EFS file system\n// ... other configuration ...\nconst example = new aws.lambda.Function(\"example\", {\n    fileSystemConfig: {\n        arn: accessPointForLambda.arn,\n        localMountPath: \"/mnt/efs\",\n    },\n    vpcConfig: {\n        subnetIds: [aws_subnet.subnet_for_lambda.id],\n        securityGroupIds: [aws_security_group.sg_for_lambda.id],\n    },\n}, {\n    dependsOn: [alpha],\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\n\n# EFS file system\nefs_for_lambda = aws.efs.FileSystem(\"efsForLambda\", tags={\n    \"Name\": \"efs_for_lambda\",\n})\n# Mount target connects the file system to the subnet\nalpha = aws.efs.MountTarget(\"alpha\",\n    file_system_id=efs_for_lambda.id,\n    subnet_id=aws_subnet[\"subnet_for_lambda\"][\"id\"],\n    security_groups=[aws_security_group[\"sg_for_lambda\"][\"id\"]])\n# EFS access point used by lambda file system\naccess_point_for_lambda = aws.efs.AccessPoint(\"accessPointForLambda\",\n    file_system_id=efs_for_lambda.id,\n    root_directory=aws.efs.AccessPointRootDirectoryArgs(\n        path=\"/lambda\",\n        creation_info=aws.efs.AccessPointRootDirectoryCreationInfoArgs(\n            owner_gid=1000,\n            owner_uid=1000,\n            permissions=\"777\",\n        ),\n    ),\n    posix_user=aws.efs.AccessPointPosixUserArgs(\n        gid=1000,\n        uid=1000,\n    ))\n# A lambda function connected to an EFS file system\n# ... other configuration ...\nexample = aws.lambda_.Function(\"example\",\n    file_system_config=aws.lambda_.FunctionFileSystemConfigArgs(\n        arn=access_point_for_lambda.arn,\n        local_mount_path=\"/mnt/efs\",\n    ),\n    vpc_config=aws.lambda_.FunctionVpcConfigArgs(\n        subnet_ids=[aws_subnet[\"subnet_for_lambda\"][\"id\"]],\n        security_group_ids=[aws_security_group[\"sg_for_lambda\"][\"id\"]],\n    ),\n    opts=pulumi.ResourceOptions(depends_on=[alpha]))\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\n\nreturn await Deployment.RunAsync(() => \n{\n    // EFS file system\n    var efsForLambda = new Aws.Efs.FileSystem(\"efsForLambda\", new()\n    {\n        Tags = \n        {\n            { \"Name\", \"efs_for_lambda\" },\n        },\n    });\n\n    // Mount target connects the file system to the subnet\n    var alpha = new Aws.Efs.MountTarget(\"alpha\", new()\n    {\n        FileSystemId = efsForLambda.Id,\n        SubnetId = aws_subnet.Subnet_for_lambda.Id,\n        SecurityGroups = new[]\n        {\n            aws_security_group.Sg_for_lambda.Id,\n        },\n    });\n\n    // EFS access point used by lambda file system\n    var accessPointForLambda = new Aws.Efs.AccessPoint(\"accessPointForLambda\", new()\n    {\n        FileSystemId = efsForLambda.Id,\n        RootDirectory = new Aws.Efs.Inputs.AccessPointRootDirectoryArgs\n        {\n            Path = \"/lambda\",\n            CreationInfo = new Aws.Efs.Inputs.AccessPointRootDirectoryCreationInfoArgs\n            {\n                OwnerGid = 1000,\n                OwnerUid = 1000,\n                Permissions = \"777\",\n            },\n        },\n        PosixUser = new Aws.Efs.Inputs.AccessPointPosixUserArgs\n        {\n            Gid = 1000,\n            Uid = 1000,\n        },\n    });\n\n    // A lambda function connected to an EFS file system\n    // ... other configuration ...\n    var example = new Aws.Lambda.Function(\"example\", new()\n    {\n        FileSystemConfig = new Aws.Lambda.Inputs.FunctionFileSystemConfigArgs\n        {\n            Arn = accessPointForLambda.Arn,\n            LocalMountPath = \"/mnt/efs\",\n        },\n        VpcConfig = new Aws.Lambda.Inputs.FunctionVpcConfigArgs\n        {\n            SubnetIds = new[]\n            {\n                aws_subnet.Subnet_for_lambda.Id,\n            },\n            SecurityGroupIds = new[]\n            {\n                aws_security_group.Sg_for_lambda.Id,\n            },\n        },\n    }, new CustomResourceOptions\n    {\n        DependsOn = new[]\n        {\n            alpha,\n        },\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/efs\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lambda\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tefsForLambda, err := efs.NewFileSystem(ctx, \"efsForLambda\", &efs.FileSystemArgs{\n\t\t\tTags: pulumi.StringMap{\n\t\t\t\t\"Name\": pulumi.String(\"efs_for_lambda\"),\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\talpha, err := efs.NewMountTarget(ctx, \"alpha\", &efs.MountTargetArgs{\n\t\t\tFileSystemId: efsForLambda.ID(),\n\t\t\tSubnetId:     pulumi.Any(aws_subnet.Subnet_for_lambda.Id),\n\t\t\tSecurityGroups: pulumi.StringArray{\n\t\t\t\tpulumi.Any(aws_security_group.Sg_for_lambda.Id),\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\taccessPointForLambda, err := efs.NewAccessPoint(ctx, \"accessPointForLambda\", &efs.AccessPointArgs{\n\t\t\tFileSystemId: efsForLambda.ID(),\n\t\t\tRootDirectory: &efs.AccessPointRootDirectoryArgs{\n\t\t\t\tPath: pulumi.String(\"/lambda\"),\n\t\t\t\tCreationInfo: &efs.AccessPointRootDirectoryCreationInfoArgs{\n\t\t\t\t\tOwnerGid:    pulumi.Int(1000),\n\t\t\t\t\tOwnerUid:    pulumi.Int(1000),\n\t\t\t\t\tPermissions: pulumi.String(\"777\"),\n\t\t\t\t},\n\t\t\t},\n\t\t\tPosixUser: &efs.AccessPointPosixUserArgs{\n\t\t\t\tGid: pulumi.Int(1000),\n\t\t\t\tUid: pulumi.Int(1000),\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = lambda.NewFunction(ctx, \"example\", &lambda.FunctionArgs{\n\t\t\tFileSystemConfig: &lambda.FunctionFileSystemConfigArgs{\n\t\t\t\tArn:            accessPointForLambda.Arn,\n\t\t\t\tLocalMountPath: pulumi.String(\"/mnt/efs\"),\n\t\t\t},\n\t\t\tVpcConfig: &lambda.FunctionVpcConfigArgs{\n\t\t\t\tSubnetIds: pulumi.StringArray{\n\t\t\t\t\tpulumi.Any(aws_subnet.Subnet_for_lambda.Id),\n\t\t\t\t},\n\t\t\t\tSecurityGroupIds: pulumi.StringArray{\n\t\t\t\t\tpulumi.Any(aws_security_group.Sg_for_lambda.Id),\n\t\t\t\t},\n\t\t\t},\n\t\t}, pulumi.DependsOn([]pulumi.Resource{\n\t\t\talpha,\n\t\t}))\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.aws.efs.FileSystem;\nimport com.pulumi.aws.efs.FileSystemArgs;\nimport com.pulumi.aws.efs.MountTarget;\nimport com.pulumi.aws.efs.MountTargetArgs;\nimport com.pulumi.aws.efs.AccessPoint;\nimport com.pulumi.aws.efs.AccessPointArgs;\nimport com.pulumi.aws.efs.inputs.AccessPointRootDirectoryArgs;\nimport com.pulumi.aws.efs.inputs.AccessPointRootDirectoryCreationInfoArgs;\nimport com.pulumi.aws.efs.inputs.AccessPointPosixUserArgs;\nimport com.pulumi.aws.lambda.Function;\nimport com.pulumi.aws.lambda.FunctionArgs;\nimport com.pulumi.aws.lambda.inputs.FunctionFileSystemConfigArgs;\nimport com.pulumi.aws.lambda.inputs.FunctionVpcConfigArgs;\nimport com.pulumi.resources.CustomResourceOptions;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var efsForLambda = new FileSystem(\"efsForLambda\", FileSystemArgs.builder()        \n            .tags(Map.of(\"Name\", \"efs_for_lambda\"))\n            .build());\n\n        var alpha = new MountTarget(\"alpha\", MountTargetArgs.builder()        \n            .fileSystemId(efsForLambda.id())\n            .subnetId(aws_subnet.subnet_for_lambda().id())\n            .securityGroups(aws_security_group.sg_for_lambda().id())\n            .build());\n\n        var accessPointForLambda = new AccessPoint(\"accessPointForLambda\", AccessPointArgs.builder()        \n            .fileSystemId(efsForLambda.id())\n            .rootDirectory(AccessPointRootDirectoryArgs.builder()\n                .path(\"/lambda\")\n                .creationInfo(AccessPointRootDirectoryCreationInfoArgs.builder()\n                    .ownerGid(1000)\n                    .ownerUid(1000)\n                    .permissions(\"777\")\n                    .build())\n                .build())\n            .posixUser(AccessPointPosixUserArgs.builder()\n                .gid(1000)\n                .uid(1000)\n                .build())\n            .build());\n\n        var example = new Function(\"example\", FunctionArgs.builder()        \n            .fileSystemConfig(FunctionFileSystemConfigArgs.builder()\n                .arn(accessPointForLambda.arn())\n                .localMountPath(\"/mnt/efs\")\n                .build())\n            .vpcConfig(FunctionVpcConfigArgs.builder()\n                .subnetIds(aws_subnet.subnet_for_lambda().id())\n                .securityGroupIds(aws_security_group.sg_for_lambda().id())\n                .build())\n            .build(), CustomResourceOptions.builder()\n                .dependsOn(alpha)\n                .build());\n\n    }\n}\n```\n```yaml\nresources:\n  # A lambda function connected to an EFS file system\n  example:\n    type: aws:lambda:Function\n    properties:\n      fileSystemConfig:\n        arn: ${accessPointForLambda.arn}\n        localMountPath: /mnt/efs\n      vpcConfig:\n        subnetIds:\n          - ${aws_subnet.subnet_for_lambda.id}\n        securityGroupIds:\n          - ${aws_security_group.sg_for_lambda.id}\n    options:\n      dependson:\n        - ${alpha}\n  # EFS file system\n  efsForLambda:\n    type: aws:efs:FileSystem\n    properties:\n      tags:\n        Name: efs_for_lambda\n  # Mount target connects the file system to the subnet\n  alpha:\n    type: aws:efs:MountTarget\n    properties:\n      fileSystemId: ${efsForLambda.id}\n      subnetId: ${aws_subnet.subnet_for_lambda.id}\n      securityGroups:\n        - ${aws_security_group.sg_for_lambda.id}\n  # EFS access point used by lambda file system\n  accessPointForLambda:\n    type: aws:efs:AccessPoint\n    properties:\n      fileSystemId: ${efsForLambda.id}\n      rootDirectory:\n        path: /lambda\n        creationInfo:\n          ownerGid: 1000\n          ownerUid: 1000\n          permissions: 777\n      posixUser:\n        gid: 1000\n        uid: 1000\n```\n{{% /example %}}\n{{% example %}}\n### CloudWatch Logging and Permissions\n\nFor more information about CloudWatch Logs for Lambda, see the [Lambda User Guide](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-logs.html).\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\n\nconst config = new pulumi.Config();\nconst lambdaFunctionName = config.get(\"lambdaFunctionName\") || \"lambda_function_name\";\n// This is to optionally manage the CloudWatch Log Group for the Lambda Function.\n// If skipping this resource configuration, also add \"logs:CreateLogGroup\" to the IAM policy below.\nconst example = new aws.cloudwatch.LogGroup(\"example\", {retentionInDays: 14});\n// See also the following AWS managed policy: AWSLambdaBasicExecutionRole\nconst lambdaLogging = new aws.iam.Policy(\"lambdaLogging\", {\n    path: \"/\",\n    description: \"IAM policy for logging from a lambda\",\n    policy: `{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"logs:CreateLogGroup\",\n        \"logs:CreateLogStream\",\n        \"logs:PutLogEvents\"\n      ],\n      \"Resource\": \"arn:aws:logs:*:*:*\",\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n`,\n});\nconst lambdaLogs = new aws.iam.RolePolicyAttachment(\"lambdaLogs\", {\n    role: aws_iam_role.iam_for_lambda.name,\n    policyArn: lambdaLogging.arn,\n});\nconst testLambda = new aws.lambda.Function(\"testLambda\", {}, {\n    dependsOn: [\n        lambdaLogs,\n        example,\n    ],\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\n\nconfig = pulumi.Config()\nlambda_function_name = config.get(\"lambdaFunctionName\")\nif lambda_function_name is None:\n    lambda_function_name = \"lambda_function_name\"\n# This is to optionally manage the CloudWatch Log Group for the Lambda Function.\n# If skipping this resource configuration, also add \"logs:CreateLogGroup\" to the IAM policy below.\nexample = aws.cloudwatch.LogGroup(\"example\", retention_in_days=14)\n# See also the following AWS managed policy: AWSLambdaBasicExecutionRole\nlambda_logging = aws.iam.Policy(\"lambdaLogging\",\n    path=\"/\",\n    description=\"IAM policy for logging from a lambda\",\n    policy=\"\"\"{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"logs:CreateLogGroup\",\n        \"logs:CreateLogStream\",\n        \"logs:PutLogEvents\"\n      ],\n      \"Resource\": \"arn:aws:logs:*:*:*\",\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n\"\"\")\nlambda_logs = aws.iam.RolePolicyAttachment(\"lambdaLogs\",\n    role=aws_iam_role[\"iam_for_lambda\"][\"name\"],\n    policy_arn=lambda_logging.arn)\ntest_lambda = aws.lambda_.Function(\"testLambda\", opts=pulumi.ResourceOptions(depends_on=[\n        lambda_logs,\n        example,\n    ]))\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\n\nreturn await Deployment.RunAsync(() => \n{\n    var config = new Config();\n    var lambdaFunctionName = config.Get(\"lambdaFunctionName\") ?? \"lambda_function_name\";\n    // This is to optionally manage the CloudWatch Log Group for the Lambda Function.\n    // If skipping this resource configuration, also add \"logs:CreateLogGroup\" to the IAM policy below.\n    var example = new Aws.CloudWatch.LogGroup(\"example\", new()\n    {\n        RetentionInDays = 14,\n    });\n\n    // See also the following AWS managed policy: AWSLambdaBasicExecutionRole\n    var lambdaLogging = new Aws.Iam.Policy(\"lambdaLogging\", new()\n    {\n        Path = \"/\",\n        Description = \"IAM policy for logging from a lambda\",\n        PolicyDocument = @\"{\n  \"\"Version\"\": \"\"2012-10-17\"\",\n  \"\"Statement\"\": [\n    {\n      \"\"Action\"\": [\n        \"\"logs:CreateLogGroup\"\",\n        \"\"logs:CreateLogStream\"\",\n        \"\"logs:PutLogEvents\"\"\n      ],\n      \"\"Resource\"\": \"\"arn:aws:logs:*:*:*\"\",\n      \"\"Effect\"\": \"\"Allow\"\"\n    }\n  ]\n}\n\",\n    });\n\n    var lambdaLogs = new Aws.Iam.RolePolicyAttachment(\"lambdaLogs\", new()\n    {\n        Role = aws_iam_role.Iam_for_lambda.Name,\n        PolicyArn = lambdaLogging.Arn,\n    });\n\n    var testLambda = new Aws.Lambda.Function(\"testLambda\", new()\n    {\n    }, new CustomResourceOptions\n    {\n        DependsOn = new[]\n        {\n            lambdaLogs,\n            example,\n        },\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/cloudwatch\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lambda\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tcfg := config.New(ctx, \"\")\n\t\tlambdaFunctionName := \"lambda_function_name\"\n\t\tif param := cfg.Get(\"lambdaFunctionName\"); param != \"\" {\n\t\t\tlambdaFunctionName = param\n\t\t}\n\t\texample, err := cloudwatch.NewLogGroup(ctx, \"example\", &cloudwatch.LogGroupArgs{\n\t\t\tRetentionInDays: pulumi.Int(14),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tlambdaLogging, err := iam.NewPolicy(ctx, \"lambdaLogging\", &iam.PolicyArgs{\n\t\t\tPath:        pulumi.String(\"/\"),\n\t\t\tDescription: pulumi.String(\"IAM policy for logging from a lambda\"),\n\t\t\tPolicy: pulumi.Any(fmt.Sprintf(`{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"logs:CreateLogGroup\",\n        \"logs:CreateLogStream\",\n        \"logs:PutLogEvents\"\n      ],\n      \"Resource\": \"arn:aws:logs:*:*:*\",\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n`)),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tlambdaLogs, err := iam.NewRolePolicyAttachment(ctx, \"lambdaLogs\", &iam.RolePolicyAttachmentArgs{\n\t\t\tRole:      pulumi.Any(aws_iam_role.Iam_for_lambda.Name),\n\t\t\tPolicyArn: lambdaLogging.Arn,\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = lambda.NewFunction(ctx, \"testLambda\", nil, pulumi.DependsOn([]pulumi.Resource{\n\t\t\tlambdaLogs,\n\t\t\texample,\n\t\t}))\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.aws.cloudwatch.LogGroup;\nimport com.pulumi.aws.cloudwatch.LogGroupArgs;\nimport com.pulumi.aws.iam.Policy;\nimport com.pulumi.aws.iam.PolicyArgs;\nimport com.pulumi.aws.iam.RolePolicyAttachment;\nimport com.pulumi.aws.iam.RolePolicyAttachmentArgs;\nimport com.pulumi.aws.lambda.Function;\nimport com.pulumi.aws.lambda.FunctionArgs;\nimport com.pulumi.resources.CustomResourceOptions;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        final var config = ctx.config();\n        final var lambdaFunctionName = config.get(\"lambdaFunctionName\").orElse(\"lambda_function_name\");\n        var example = new LogGroup(\"example\", LogGroupArgs.builder()        \n            .retentionInDays(14)\n            .build());\n\n        var lambdaLogging = new Policy(\"lambdaLogging\", PolicyArgs.builder()        \n            .path(\"/\")\n            .description(\"IAM policy for logging from a lambda\")\n            .policy(\"\"\"\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"logs:CreateLogGroup\",\n        \"logs:CreateLogStream\",\n        \"logs:PutLogEvents\"\n      ],\n      \"Resource\": \"arn:aws:logs:*:*:*\",\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n            \"\"\")\n            .build());\n\n        var lambdaLogs = new RolePolicyAttachment(\"lambdaLogs\", RolePolicyAttachmentArgs.builder()        \n            .role(aws_iam_role.iam_for_lambda().name())\n            .policyArn(lambdaLogging.arn())\n            .build());\n\n        var testLambda = new Function(\"testLambda\", FunctionArgs.Empty, CustomResourceOptions.builder()\n            .dependsOn(            \n                lambdaLogs,\n                example)\n            .build());\n\n    }\n}\n```\n```yaml\nconfiguration:\n  lambdaFunctionName:\n    type: string\n    default: lambda_function_name\nresources:\n  testLambda:\n    type: aws:lambda:Function\n    options:\n      dependson:\n        - ${lambdaLogs}\n        - ${example}\n  # This is to optionally manage the CloudWatch Log Group for the Lambda Function.\n  # If skipping this resource configuration, also add \"logs:CreateLogGroup\" to the IAM policy below.\n  example:\n    type: aws:cloudwatch:LogGroup\n    properties:\n      retentionInDays: 14\n  # See also the following AWS managed policy: AWSLambdaBasicExecutionRole\n  lambdaLogging:\n    type: aws:iam:Policy\n    properties:\n      path: /\n      description: IAM policy for logging from a lambda\n      policy: |\n        {\n          \"Version\": \"2012-10-17\",\n          \"Statement\": [\n            {\n              \"Action\": [\n                \"logs:CreateLogGroup\",\n                \"logs:CreateLogStream\",\n                \"logs:PutLogEvents\"\n              ],\n              \"Resource\": \"arn:aws:logs:*:*:*\",\n              \"Effect\": \"Allow\"\n            }\n          ]\n        }\n  lambdaLogs:\n    type: aws:iam:RolePolicyAttachment\n    properties:\n      role: ${aws_iam_role.iam_for_lambda.name}\n      policyArn: ${lambdaLogging.arn}\n```\n{{% /example %}}\n{{% example %}}\n### Lambda with Targetted Architecture\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\n\nconst iamForLambda = new aws.iam.Role(\"iamForLambda\", {assumeRolePolicy: `{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n`});\nconst testLambda = new aws.lambda.Function(\"testLambda\", {\n    code: new pulumi.asset.FileArchive(\"lambda_function_payload.zip\"),\n    role: iamForLambda.arn,\n    handler: \"index.test\",\n    runtime: \"nodejs12.x\",\n    architectures: [\"arm64\"],\n    environment: {\n        variables: {\n            foo: \"bar\",\n        },\n    },\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\n\niam_for_lambda = aws.iam.Role(\"iamForLambda\", assume_role_policy=\"\"\"{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n\"\"\")\ntest_lambda = aws.lambda_.Function(\"testLambda\",\n    code=pulumi.FileArchive(\"lambda_function_payload.zip\"),\n    role=iam_for_lambda.arn,\n    handler=\"index.test\",\n    runtime=\"nodejs12.x\",\n    architectures=[\"arm64\"],\n    environment=aws.lambda_.FunctionEnvironmentArgs(\n        variables={\n            \"foo\": \"bar\",\n        },\n    ))\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\n\nreturn await Deployment.RunAsync(() => \n{\n    var iamForLambda = new Aws.Iam.Role(\"iamForLambda\", new()\n    {\n        AssumeRolePolicy = @\"{\n  \"\"Version\"\": \"\"2012-10-17\"\",\n  \"\"Statement\"\": [\n    {\n      \"\"Action\"\": \"\"sts:AssumeRole\"\",\n      \"\"Principal\"\": {\n        \"\"Service\"\": \"\"lambda.amazonaws.com\"\"\n      },\n      \"\"Effect\"\": \"\"Allow\"\",\n      \"\"Sid\"\": \"\"\"\"\n    }\n  ]\n}\n\",\n    });\n\n    var testLambda = new Aws.Lambda.Function(\"testLambda\", new()\n    {\n        Code = new FileArchive(\"lambda_function_payload.zip\"),\n        Role = iamForLambda.Arn,\n        Handler = \"index.test\",\n        Runtime = \"nodejs12.x\",\n        Architectures = new[]\n        {\n            \"arm64\",\n        },\n        Environment = new Aws.Lambda.Inputs.FunctionEnvironmentArgs\n        {\n            Variables = \n            {\n                { \"foo\", \"bar\" },\n            },\n        },\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lambda\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tiamForLambda, err := iam.NewRole(ctx, \"iamForLambda\", &iam.RoleArgs{\n\t\t\tAssumeRolePolicy: pulumi.Any(fmt.Sprintf(`{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n`)),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = lambda.NewFunction(ctx, \"testLambda\", &lambda.FunctionArgs{\n\t\t\tCode:    pulumi.NewFileArchive(\"lambda_function_payload.zip\"),\n\t\t\tRole:    iamForLambda.Arn,\n\t\t\tHandler: pulumi.String(\"index.test\"),\n\t\t\tRuntime: pulumi.String(\"nodejs12.x\"),\n\t\t\tArchitectures: pulumi.StringArray{\n\t\t\t\tpulumi.String(\"arm64\"),\n\t\t\t},\n\t\t\tEnvironment: &lambda.FunctionEnvironmentArgs{\n\t\t\t\tVariables: pulumi.StringMap{\n\t\t\t\t\t\"foo\": pulumi.String(\"bar\"),\n\t\t\t\t},\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.aws.iam.Role;\nimport com.pulumi.aws.iam.RoleArgs;\nimport com.pulumi.aws.lambda.Function;\nimport com.pulumi.aws.lambda.FunctionArgs;\nimport com.pulumi.aws.lambda.inputs.FunctionEnvironmentArgs;\nimport com.pulumi.asset.FileArchive;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var iamForLambda = new Role(\"iamForLambda\", RoleArgs.builder()        \n            .assumeRolePolicy(\"\"\"\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\n            \"\"\")\n            .build());\n\n        var testLambda = new Function(\"testLambda\", FunctionArgs.builder()        \n            .code(new FileArchive(\"lambda_function_payload.zip\"))\n            .role(iamForLambda.arn())\n            .handler(\"index.test\")\n            .runtime(\"nodejs12.x\")\n            .architectures(\"arm64\")\n            .environment(FunctionEnvironmentArgs.builder()\n                .variables(Map.of(\"foo\", \"bar\"))\n                .build())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  iamForLambda:\n    type: aws:iam:Role\n    properties:\n      assumeRolePolicy: |\n        {\n          \"Version\": \"2012-10-17\",\n          \"Statement\": [\n            {\n              \"Action\": \"sts:AssumeRole\",\n              \"Principal\": {\n                \"Service\": \"lambda.amazonaws.com\"\n              },\n              \"Effect\": \"Allow\",\n              \"Sid\": \"\"\n            }\n          ]\n        }\n  testLambda:\n    type: aws:lambda:Function\n    properties:\n      code:\n        Fn::FileArchive: lambda_function_payload.zip\n      role: ${iamForLambda.arn}\n      handler: index.test\n      runtime: nodejs12.x\n      architectures:\n        - arm64\n      environment:\n        variables:\n          foo: bar\n```\n\nOnce you have created your deployment package you can specify it either directly as a local file (using the `filename` argument) or indirectly via Amazon S3 (using the `s3_bucket`, `s3_key` and `s3_object_version` arguments). When providing the deployment package via S3 it may be useful to use the `aws.s3.BucketObjectv2` resource to upload it.\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nLambda Functions can be imported using the `function_name`, e.g.,\n\n```sh\n $ pulumi import aws:lambda/function:Function test_lambda my_test_lambda_function\n```\n\n ",
+      "description": "Provides a Lambda Function resource. Lambda<<shortened>>n test_lambda my_test_lambda_function\n```\n\n ",
       "properties": {
         "architectures": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Instruction set architecture for your Lambda function. Valid values are `[\"x86_64\"]` and `[\"arm64\"]`. Default is `[\"x86_64\"]`. Removing this attribute, function's architecture stay the same.\n"
+          "description": "Instruction set architecture for your Lambd<<shortened>>ute, function's architecture stay the same.\n"
         },
         "arn": {
           "type": "string",
@@ -473,11 +328,11 @@
         },
         "code": {
           "$ref": "pulumi.json#/Archive",
-          "description": "Path to the function's deployment package within the local filesystem. Conflicts with `image_uri`, `s3_bucket`, `s3_key`, and `s3_object_version`.\n"
+          "description": "Path to the function's deployment package w<<shortened>>bucket`, `s3_key`, and `s3_object_version`.\n"
         },
         "codeSigningConfigArn": {
           "type": "string",
-          "description": "To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function.\n"
+          "description": "To enable code signing for this function, s<<shortened>>e the trusted publishers for this function.\n"
         },
         "deadLetterConfig": {
           "$ref": "#/types/aws:lambda/FunctionDeadLetterConfig:FunctionDeadLetterConfig",
@@ -493,7 +348,7 @@
         },
         "ephemeralStorage": {
           "$ref": "#/types/aws:lambda/FunctionEphemeralStorage:FunctionEphemeralStorage",
-          "description": "The amount of Ephemeral storage(`/tmp`) to allocate for the Lambda Function in MB. This parameter is used to expand the total amount of Ephemeral storage available, beyond the default amount of `512`MB. Detailed below.\n"
+          "description": "The amount of Ephemeral storage(`/tmp`) to <<shortened>> default amount of `512`MB. Detailed below.\n"
         },
         "fileSystemConfig": {
           "$ref": "#/types/aws:lambda/FunctionFileSystemConfig:FunctionFileSystemConfig",
@@ -501,7 +356,7 @@
         },
         "handler": {
           "type": "string",
-          "description": "Function [entrypoint](https://docs.aws.amazon.com/lambda/latest/dg/walkthrough-custom-events-create-test-function.html) in your code.\n"
+          "description": "Function [entrypoint](https://docs.aws.amaz<<shortened>>ts-create-test-function.html) in your code.\n"
         },
         "imageConfig": {
           "$ref": "#/types/aws:lambda/FunctionImageConfig:FunctionImageConfig",
@@ -509,15 +364,15 @@
         },
         "imageUri": {
           "type": "string",
-          "description": "ECR image URI containing the function's deployment package. Conflicts with `filename`, `s3_bucket`, `s3_key`, and `s3_object_version`.\n"
+          "description": "ECR image URI containing the function's dep<<shortened>>bucket`, `s3_key`, and `s3_object_version`.\n"
         },
         "invokeArn": {
           "type": "string",
-          "description": "ARN to be used for invoking Lambda Function from API Gateway - to be used in `aws.apigateway.Integration`'s `uri`.\n"
+          "description": "ARN to be used for invoking Lambda Function<<shortened>>ed in `aws.apigateway.Integration`'s `uri`.\n"
         },
         "kmsKeyArn": {
           "type": "string",
-          "description": "Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables. If this configuration is not provided when environment variables are in use, AWS Lambda uses a default service key. If this configuration is provided when environment variables are not in use, the AWS Lambda API does not save this configuration and the provider will show a perpetual difference of adding the key. To fix the perpetual difference, remove this configuration.\n"
+          "description": "Amazon Resource Name (ARN) of the AWS Key M<<shortened>>tual difference, remove this configuration.\n"
         },
         "lastModified": {
           "type": "string",
@@ -528,11 +383,11 @@
           "items": {
             "type": "string"
           },
-          "description": "List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)\n"
+          "description": "List of Lambda Layer Version ARNs (maximum <<shortened>>lambda/latest/dg/configuration-layers.html)\n"
         },
         "memorySize": {
           "type": "integer",
-          "description": "Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)\n"
+          "description": "Amount of memory in MB your Lambda Function<<shortened>>ws.amazon.com/lambda/latest/dg/limits.html)\n"
         },
         "name": {
           "type": "string",
@@ -552,32 +407,32 @@
         },
         "qualifiedInvokeArn": {
           "type": "string",
-          "description": "Qualified ARN (ARN with lambda version number) to be used for invoking Lambda Function from API Gateway - to be used in [`aws.apigateway.Integration`](https://www.terraform.io/docs/providers/aws/r/api_gateway_integration.html)'s `uri`.\n"
+          "description": "Qualified ARN (ARN with lambda version numb<<shortened>>ws/r/api_gateway_integration.html)'s `uri`.\n"
         },
         "reservedConcurrentExecutions": {
           "type": "integer",
-          "description": "Amount of reserved concurrent executions for this lambda function. A value of `0` disables lambda from being triggered and `-1` removes any concurrency limitations. Defaults to Unreserved Concurrency Limits `-1`. See [Managing Concurrency](https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html)\n"
+          "description": "Amount of reserved concurrent executions fo<<shortened>>ambda/latest/dg/concurrent-executions.html)\n"
         },
         "role": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "Amazon Resource Name (ARN) of the function's execution role. The role provides the function's identity and access to AWS services and resources.\n"
+          "description": "Amazon Resource Name (ARN) of the function'<<shortened>>y and access to AWS services and resources.\n"
         },
         "runtime": {
           "type": "string",
-          "description": "Identifier of the function's runtime. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for valid values.\n"
+          "description": "Identifier of the function's runtime. See [<<shortened>>Function-request-Runtime) for valid values.\n"
         },
         "s3Bucket": {
           "type": "string",
-          "description": "S3 bucket location containing the function's deployment package. Conflicts with `filename` and `image_uri`. This bucket must reside in the same AWS region where you are creating the Lambda function.\n"
+          "description": "S3 bucket location containing the function'<<shortened>>where you are creating the Lambda function.\n"
         },
         "s3Key": {
           "type": "string",
-          "description": "S3 key of an object containing the function's deployment package. Conflicts with `filename` and `image_uri`.\n"
+          "description": "S3 key of an object containing the function<<shortened>> Conflicts with `filename` and `image_uri`.\n"
         },
         "s3ObjectVersion": {
           "type": "string",
-          "description": "Object version containing the function's deployment package. Conflicts with `filename` and `image_uri`.\n"
+          "description": "Object version containing the function's de<<shortened>> Conflicts with `filename` and `image_uri`.\n"
         },
         "signingJobArn": {
           "type": "string",
@@ -589,7 +444,7 @@
         },
         "sourceCodeHash": {
           "type": "string",
-          "description": "Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `filebase64sha256(\"file.zip\")`, where \"file.zip\" is the local filename of the lambda function source archive.\n"
+          "description": "Used to trigger updates. Must be set to a b<<shortened>>name of the lambda function source archive.\n"
         },
         "sourceCodeSize": {
           "type": "integer",
@@ -600,18 +455,18 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Map of tags to assign to the object. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.\n"
+          "description": "Map of tags to assign to the object. If con<<shortened>>rwrite those defined at the provider-level.\n"
         },
         "tagsAll": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.\n"
+          "description": "A map of tags assigned to the resource, inc<<shortened>>rovider `default_tags` configuration block.\n"
         },
         "timeout": {
           "type": "integer",
-          "description": "Amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html).\n"
+          "description": "Amount of time your Lambda Function has to <<shortened>>s.amazon.com/lambda/latest/dg/limits.html).\n"
         },
         "tracingConfig": {
           "$ref": "#/types/aws:lambda/FunctionTracingConfig:FunctionTracingConfig",
@@ -650,15 +505,15 @@
           "items": {
             "type": "string"
           },
-          "description": "Instruction set architecture for your Lambda function. Valid values are `[\"x86_64\"]` and `[\"arm64\"]`. Default is `[\"x86_64\"]`. Removing this attribute, function's architecture stay the same.\n"
+          "description": "Instruction set architecture for your Lambd<<shortened>>ute, function's architecture stay the same.\n"
         },
         "code": {
           "$ref": "pulumi.json#/Archive",
-          "description": "Path to the function's deployment package within the local filesystem. Conflicts with `image_uri`, `s3_bucket`, `s3_key`, and `s3_object_version`.\n"
+          "description": "Path to the function's deployment package w<<shortened>>bucket`, `s3_key`, and `s3_object_version`.\n"
         },
         "codeSigningConfigArn": {
           "type": "string",
-          "description": "To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function.\n"
+          "description": "To enable code signing for this function, s<<shortened>>e the trusted publishers for this function.\n"
         },
         "deadLetterConfig": {
           "$ref": "#/types/aws:lambda/FunctionDeadLetterConfig:FunctionDeadLetterConfig",
@@ -674,7 +529,7 @@
         },
         "ephemeralStorage": {
           "$ref": "#/types/aws:lambda/FunctionEphemeralStorage:FunctionEphemeralStorage",
-          "description": "The amount of Ephemeral storage(`/tmp`) to allocate for the Lambda Function in MB. This parameter is used to expand the total amount of Ephemeral storage available, beyond the default amount of `512`MB. Detailed below.\n"
+          "description": "The amount of Ephemeral storage(`/tmp`) to <<shortened>> default amount of `512`MB. Detailed below.\n"
         },
         "fileSystemConfig": {
           "$ref": "#/types/aws:lambda/FunctionFileSystemConfig:FunctionFileSystemConfig",
@@ -682,7 +537,7 @@
         },
         "handler": {
           "type": "string",
-          "description": "Function [entrypoint](https://docs.aws.amazon.com/lambda/latest/dg/walkthrough-custom-events-create-test-function.html) in your code.\n"
+          "description": "Function [entrypoint](https://docs.aws.amaz<<shortened>>ts-create-test-function.html) in your code.\n"
         },
         "imageConfig": {
           "$ref": "#/types/aws:lambda/FunctionImageConfig:FunctionImageConfig",
@@ -690,22 +545,22 @@
         },
         "imageUri": {
           "type": "string",
-          "description": "ECR image URI containing the function's deployment package. Conflicts with `filename`, `s3_bucket`, `s3_key`, and `s3_object_version`.\n"
+          "description": "ECR image URI containing the function's dep<<shortened>>bucket`, `s3_key`, and `s3_object_version`.\n"
         },
         "kmsKeyArn": {
           "type": "string",
-          "description": "Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables. If this configuration is not provided when environment variables are in use, AWS Lambda uses a default service key. If this configuration is provided when environment variables are not in use, the AWS Lambda API does not save this configuration and the provider will show a perpetual difference of adding the key. To fix the perpetual difference, remove this configuration.\n"
+          "description": "Amazon Resource Name (ARN) of the AWS Key M<<shortened>>tual difference, remove this configuration.\n"
         },
         "layers": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)\n"
+          "description": "List of Lambda Layer Version ARNs (maximum <<shortened>>lambda/latest/dg/configuration-layers.html)\n"
         },
         "memorySize": {
           "type": "integer",
-          "description": "Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)\n"
+          "description": "Amount of memory in MB your Lambda Function<<shortened>>ws.amazon.com/lambda/latest/dg/limits.html)\n"
         },
         "name": {
           "type": "string",
@@ -723,12 +578,12 @@
         },
         "reservedConcurrentExecutions": {
           "type": "integer",
-          "description": "Amount of reserved concurrent executions for this lambda function. A value of `0` disables lambda from being triggered and `-1` removes any concurrency limitations. Defaults to Unreserved Concurrency Limits `-1`. See [Managing Concurrency](https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html)\n"
+          "description": "Amount of reserved concurrent executions fo<<shortened>>ambda/latest/dg/concurrent-executions.html)\n"
         },
         "role": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "Amazon Resource Name (ARN) of the function's execution role. The role provides the function's identity and access to AWS services and resources.\n"
+          "description": "Amazon Resource Name (ARN) of the function'<<shortened>>y and access to AWS services and resources.\n"
         },
         "runtime": {
           "type": "string",
@@ -741,41 +596,41 @@
               "$ref": "#/types/aws:lambda/Runtime:Runtime"
             }
           ],
-          "description": "Identifier of the function's runtime. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for valid values.\n"
+          "description": "Identifier of the function's runtime. See [<<shortened>>Function-request-Runtime) for valid values.\n"
         },
         "s3Bucket": {
           "type": "string",
-          "description": "S3 bucket location containing the function's deployment package. Conflicts with `filename` and `image_uri`. This bucket must reside in the same AWS region where you are creating the Lambda function.\n"
+          "description": "S3 bucket location containing the function'<<shortened>>where you are creating the Lambda function.\n"
         },
         "s3Key": {
           "type": "string",
-          "description": "S3 key of an object containing the function's deployment package. Conflicts with `filename` and `image_uri`.\n"
+          "description": "S3 key of an object containing the function<<shortened>> Conflicts with `filename` and `image_uri`.\n"
         },
         "s3ObjectVersion": {
           "type": "string",
-          "description": "Object version containing the function's deployment package. Conflicts with `filename` and `image_uri`.\n"
+          "description": "Object version containing the function's de<<shortened>> Conflicts with `filename` and `image_uri`.\n"
         },
         "sourceCodeHash": {
           "type": "string",
-          "description": "Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `filebase64sha256(\"file.zip\")`, where \"file.zip\" is the local filename of the lambda function source archive.\n"
+          "description": "Used to trigger updates. Must be set to a b<<shortened>>name of the lambda function source archive.\n"
         },
         "tags": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Map of tags to assign to the object. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.\n"
+          "description": "Map of tags to assign to the object. If con<<shortened>>rwrite those defined at the provider-level.\n"
         },
         "tagsAll": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.\n"
+          "description": "A map of tags assigned to the resource, inc<<shortened>>rovider `default_tags` configuration block.\n"
         },
         "timeout": {
           "type": "integer",
-          "description": "Amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html).\n"
+          "description": "Amount of time your Lambda Function has to <<shortened>>s.amazon.com/lambda/latest/dg/limits.html).\n"
         },
         "tracingConfig": {
           "$ref": "#/types/aws:lambda/FunctionTracingConfig:FunctionTracingConfig",
@@ -797,7 +652,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Instruction set architecture for your Lambda function. Valid values are `[\"x86_64\"]` and `[\"arm64\"]`. Default is `[\"x86_64\"]`. Removing this attribute, function's architecture stay the same.\n"
+            "description": "Instruction set architecture for your Lambd<<shortened>>ute, function's architecture stay the same.\n"
           },
           "arn": {
             "type": "string",
@@ -805,11 +660,11 @@
           },
           "code": {
             "$ref": "pulumi.json#/Archive",
-            "description": "Path to the function's deployment package within the local filesystem. Conflicts with `image_uri`, `s3_bucket`, `s3_key`, and `s3_object_version`.\n"
+            "description": "Path to the function's deployment package w<<shortened>>bucket`, `s3_key`, and `s3_object_version`.\n"
           },
           "codeSigningConfigArn": {
             "type": "string",
-            "description": "To enable code signing for this function, specify the ARN of a code-signing configuration. A code-signing configuration includes a set of signing profiles, which define the trusted publishers for this function.\n"
+            "description": "To enable code signing for this function, s<<shortened>>e the trusted publishers for this function.\n"
           },
           "deadLetterConfig": {
             "$ref": "#/types/aws:lambda/FunctionDeadLetterConfig:FunctionDeadLetterConfig",
@@ -825,7 +680,7 @@
           },
           "ephemeralStorage": {
             "$ref": "#/types/aws:lambda/FunctionEphemeralStorage:FunctionEphemeralStorage",
-            "description": "The amount of Ephemeral storage(`/tmp`) to allocate for the Lambda Function in MB. This parameter is used to expand the total amount of Ephemeral storage available, beyond the default amount of `512`MB. Detailed below.\n"
+            "description": "The amount of Ephemeral storage(`/tmp`) to <<shortened>> default amount of `512`MB. Detailed below.\n"
           },
           "fileSystemConfig": {
             "$ref": "#/types/aws:lambda/FunctionFileSystemConfig:FunctionFileSystemConfig",
@@ -833,7 +688,7 @@
           },
           "handler": {
             "type": "string",
-            "description": "Function [entrypoint](https://docs.aws.amazon.com/lambda/latest/dg/walkthrough-custom-events-create-test-function.html) in your code.\n"
+            "description": "Function [entrypoint](https://docs.aws.amaz<<shortened>>ts-create-test-function.html) in your code.\n"
           },
           "imageConfig": {
             "$ref": "#/types/aws:lambda/FunctionImageConfig:FunctionImageConfig",
@@ -841,15 +696,15 @@
           },
           "imageUri": {
             "type": "string",
-            "description": "ECR image URI containing the function's deployment package. Conflicts with `filename`, `s3_bucket`, `s3_key`, and `s3_object_version`.\n"
+            "description": "ECR image URI containing the function's dep<<shortened>>bucket`, `s3_key`, and `s3_object_version`.\n"
           },
           "invokeArn": {
             "type": "string",
-            "description": "ARN to be used for invoking Lambda Function from API Gateway - to be used in `aws.apigateway.Integration`'s `uri`.\n"
+            "description": "ARN to be used for invoking Lambda Function<<shortened>>ed in `aws.apigateway.Integration`'s `uri`.\n"
           },
           "kmsKeyArn": {
             "type": "string",
-            "description": "Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables. If this configuration is not provided when environment variables are in use, AWS Lambda uses a default service key. If this configuration is provided when environment variables are not in use, the AWS Lambda API does not save this configuration and the provider will show a perpetual difference of adding the key. To fix the perpetual difference, remove this configuration.\n"
+            "description": "Amazon Resource Name (ARN) of the AWS Key M<<shortened>>tual difference, remove this configuration.\n"
           },
           "lastModified": {
             "type": "string",
@@ -860,11 +715,11 @@
             "items": {
               "type": "string"
             },
-            "description": "List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)\n"
+            "description": "List of Lambda Layer Version ARNs (maximum <<shortened>>lambda/latest/dg/configuration-layers.html)\n"
           },
           "memorySize": {
             "type": "integer",
-            "description": "Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)\n"
+            "description": "Amount of memory in MB your Lambda Function<<shortened>>ws.amazon.com/lambda/latest/dg/limits.html)\n"
           },
           "name": {
             "type": "string",
@@ -886,16 +741,16 @@
           },
           "qualifiedInvokeArn": {
             "type": "string",
-            "description": "Qualified ARN (ARN with lambda version number) to be used for invoking Lambda Function from API Gateway - to be used in [`aws.apigateway.Integration`](https://www.terraform.io/docs/providers/aws/r/api_gateway_integration.html)'s `uri`.\n"
+            "description": "Qualified ARN (ARN with lambda version numb<<shortened>>ws/r/api_gateway_integration.html)'s `uri`.\n"
           },
           "reservedConcurrentExecutions": {
             "type": "integer",
-            "description": "Amount of reserved concurrent executions for this lambda function. A value of `0` disables lambda from being triggered and `-1` removes any concurrency limitations. Defaults to Unreserved Concurrency Limits `-1`. See [Managing Concurrency](https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html)\n"
+            "description": "Amount of reserved concurrent executions fo<<shortened>>ambda/latest/dg/concurrent-executions.html)\n"
           },
           "role": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
-            "description": "Amazon Resource Name (ARN) of the function's execution role. The role provides the function's identity and access to AWS services and resources.\n"
+            "description": "Amazon Resource Name (ARN) of the function'<<shortened>>y and access to AWS services and resources.\n"
           },
           "runtime": {
             "type": "string",
@@ -908,19 +763,19 @@
                 "$ref": "#/types/aws:lambda/Runtime:Runtime"
               }
             ],
-            "description": "Identifier of the function's runtime. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime) for valid values.\n"
+            "description": "Identifier of the function's runtime. See [<<shortened>>Function-request-Runtime) for valid values.\n"
           },
           "s3Bucket": {
             "type": "string",
-            "description": "S3 bucket location containing the function's deployment package. Conflicts with `filename` and `image_uri`. This bucket must reside in the same AWS region where you are creating the Lambda function.\n"
+            "description": "S3 bucket location containing the function'<<shortened>>where you are creating the Lambda function.\n"
           },
           "s3Key": {
             "type": "string",
-            "description": "S3 key of an object containing the function's deployment package. Conflicts with `filename` and `image_uri`.\n"
+            "description": "S3 key of an object containing the function<<shortened>> Conflicts with `filename` and `image_uri`.\n"
           },
           "s3ObjectVersion": {
             "type": "string",
-            "description": "Object version containing the function's deployment package. Conflicts with `filename` and `image_uri`.\n"
+            "description": "Object version containing the function's de<<shortened>> Conflicts with `filename` and `image_uri`.\n"
           },
           "signingJobArn": {
             "type": "string",
@@ -932,7 +787,7 @@
           },
           "sourceCodeHash": {
             "type": "string",
-            "description": "Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `filebase64sha256(\"file.zip\")`, where \"file.zip\" is the local filename of the lambda function source archive.\n"
+            "description": "Used to trigger updates. Must be set to a b<<shortened>>name of the lambda function source archive.\n"
           },
           "sourceCodeSize": {
             "type": "integer",
@@ -943,18 +798,18 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "Map of tags to assign to the object. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.\n"
+            "description": "Map of tags to assign to the object. If con<<shortened>>rwrite those defined at the provider-level.\n"
           },
           "tagsAll": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
             },
-            "description": "A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.\n"
+            "description": "A map of tags assigned to the resource, inc<<shortened>>rovider `default_tags` configuration block.\n"
           },
           "timeout": {
             "type": "integer",
-            "description": "Amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html).\n"
+            "description": "Amount of time your Lambda Function has to <<shortened>>s.amazon.com/lambda/latest/dg/limits.html).\n"
           },
           "tracingConfig": {
             "$ref": "#/types/aws:lambda/FunctionTracingConfig:FunctionTracingConfig",
@@ -975,7 +830,7 @@
   },
   "functions": {
     "aws:fsx/getOpenZfsSnapshot:getOpenZfsSnapshot": {
-      "description": "Use this data source to get information about an Amazon FSx for OpenZFS Snapshot for use when provisioning new Volumes.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n### Root volume Example\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\n\nconst example = pulumi.output(aws.fsx.getOpenZfsSnapshot({\n    filters: [{\n        name: \"volume-id\",\n        values: [\"fsvol-073a32b6098a73feb\"],\n    }],\n    mostRecent: true,\n}));\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\n\nexample = aws.fsx.get_open_zfs_snapshot(filters=[aws.fsx.GetOpenZfsSnapshotFilterArgs(\n        name=\"volume-id\",\n        values=[\"fsvol-073a32b6098a73feb\"],\n    )],\n    most_recent=True)\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\n\nreturn await Deployment.RunAsync(() => \n{\n    var example = Aws.Fsx.GetOpenZfsSnapshot.Invoke(new()\n    {\n        Filters = new[]\n        {\n            new Aws.Fsx.Inputs.GetOpenZfsSnapshotFilterInputArgs\n            {\n                Name = \"volume-id\",\n                Values = new[]\n                {\n                    \"fsvol-073a32b6098a73feb\",\n                },\n            },\n        },\n        MostRecent = true,\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/fsx\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\t_, err := fsx.LookupOpenZfsSnapshot(ctx, &fsx.LookupOpenZfsSnapshotArgs{\n\t\t\tFilters: []fsx.GetOpenZfsSnapshotFilter{\n\t\t\t\tfsx.GetOpenZfsSnapshotFilter{\n\t\t\t\t\tName: \"volume-id\",\n\t\t\t\t\tValues: []string{\n\t\t\t\t\t\t\"fsvol-073a32b6098a73feb\",\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t\tMostRecent: pulumi.BoolRef(true),\n\t\t}, nil)\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.aws.fsx.FsxFunctions;\nimport com.pulumi.aws.fsx.inputs.GetOpenZfsSnapshotArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        final var example = FsxFunctions.getOpenZfsSnapshot(GetOpenZfsSnapshotArgs.builder()\n            .filters(GetOpenZfsSnapshotFilterArgs.builder()\n                .name(\"volume-id\")\n                .values(\"fsvol-073a32b6098a73feb\")\n                .build())\n            .mostRecent(true)\n            .build());\n\n    }\n}\n```\n```yaml\nvariables:\n  example:\n    Fn::Invoke:\n      Function: aws:fsx:getOpenZfsSnapshot\n      Arguments:\n        filters:\n          - name: volume-id\n            values:\n              - fsvol-073a32b6098a73feb\n        mostRecent: true\n```\n{{% /example %}}\n{{% /examples %}}",
+      "description": "Use this data source to get information abo<<shortened>> true\n```\n{{% /example %}}\n{{% /examples %}}",
       "inputs": {
         "description": "A collection of arguments for invoking getOpenZfsSnapshot.\n",
         "properties": {
@@ -1073,5 +928,4 @@
       }
     }
   }
-
 }

--- a/src/test/resources/schema-azure-native-3.44.2-subset-with-ip-allocation.json
+++ b/src/test/resources/schema-azure-native-3.44.2-subset-with-ip-allocation.json
@@ -1,0 +1,31 @@
+{
+  "name": "azure-native",
+  "types": {
+    "azure-native:network:IpAllocationMethod": {
+      "description": "Private IP address allocation method.",
+      "type": "string",
+      "enum": [
+        {
+          "value": "Static"
+        },
+        {
+          "value": "Dynamic"
+        }
+      ]
+    },
+    "azure-native:network:IPAllocationMethod": {
+      "description": "The private IP address allocation method.",
+      "type": "string",
+      "enum": [
+        {
+          "value": "Static"
+        },
+        {
+          "value": "Dynamic"
+        }
+      ]
+    }
+  },
+  "resources": {},
+  "functions": {}
+}

--- a/src/test/resources/schema-azure-native-3.44.2-subset-with-recursion.json
+++ b/src/test/resources/schema-azure-native-3.44.2-subset-with-recursion.json
@@ -1,0 +1,80 @@
+{
+  "name": "azure-native",
+  "types": {
+    "azure-native:batch:ApplicationPackageReference": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string",
+          "description": "If this is omitted, and no default version is specified for this application, the request fails with the error code InvalidApplicationPackageReferences. If you are calling the REST API directly, the HTTP status code is 409."
+        }
+      },
+      "type": "object",
+      "required": [
+        "id"
+      ]
+    },
+    "azure-native:batch:ApplicationPackageReferenceResponse": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string",
+          "description": "If this is omitted, and no default version is specified for this application, the request fails with the error code InvalidApplicationPackageReferences. If you are calling the REST API directly, the HTTP status code is 409."
+        }
+      },
+      "type": "object",
+      "required": [
+        "id"
+      ]
+    },
+    "azure-native:batch:AutoScaleRunErrorResponse": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An identifier for the error. Codes are invariant and are intended to be consumed programmatically."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/types/azure-native:batch:AutoScaleRunErrorResponse"
+          }
+        },
+        "message": {
+          "type": "string",
+          "description": "A message describing the error, intended to be suitable for display in a user interface."
+        }
+      },
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "azure-native:batch:AutoScaleRunResponse": {
+      "properties": {
+        "error": {
+          "type": "object",
+          "$ref": "#/types/azure-native:batch:AutoScaleRunErrorResponse"
+        },
+        "evaluationTime": {
+          "type": "string"
+        },
+        "results": {
+          "type": "string",
+          "description": "Each variable value is returned in the form $variable=value, and variables are separated by semicolons."
+        }
+      },
+      "type": "object",
+      "required": [
+        "evaluationTime"
+      ]
+    }
+  },
+  "resources": {},
+  "functions": {}
+}


### PR DESCRIPTION
## Task

Resolves: None.
Related to: #57.

## Description

### 1.

Add `loadFullParents` option to "compute schema subset" script. See clarification here:

https://github.com/VirtuslabRnD/pulumi-kotlin/blob/4e2f33669f076922b161864422dd147e3870b6b2/src/main/kotlin/com/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScript.kt#L67-L106

### 2.

Fix naming conflicts caused by case-insensitive type names.

#### Symptom 1

Compute schema subset randomly fails when two types (A, B) contain `$ref` to some other type (B).

#### Solution 1

Remove `ConflictsNotAllowed` exception from `SetWithKeyTransformer` altogether. It does not really make sense for sets.

#### Symptom 2

Both compute schema subset script and code generation 

#### Solution 2.1 (does not really work)

Loosen up the conflict detection in `MapWithKeyTransformer` – don't throw when values are the same (references) or equal (did not really fix the bug, but I think it might still be helpful in the future).


#### Solution 2.2 (works)

Ugly fix in `Decoder` – hard-code a set of types that should be removed from the schema `setOf("azure-native:network:IpAllocationMethod")`)