### PR TITLE
Allow ejecting code from failed `CodegenTest` tests

### DIFF
--- a/.github/workflows/pulumi_kotlin.yml
+++ b/.github/workflows/pulumi_kotlin.yml
@@ -16,13 +16,21 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Compile and test code
+        id: run-tests
         run: ./gradlew build test -x check
       - name: Upload test report
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: e2e-test-report
+          name: test-report
           path: ./build/reports/tests/test/*
+          retention-days: 3
+      - name: Upload ejected-tests
+        if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ejected-tests
+          path: ./ejected-tests/
           retention-days: 3
   analyze:
     name: Analyze pulumi-kotlin

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 output-dir
 examples/gcp-sample-project/Pulumi.*.yaml
 !examples/gcp-sample-project/Pulumi.test.yaml
-
+ejected-tests
 
 ### IntelliJ ###
 **/*.idea/*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     testImplementation("com.google.cloud:google-cloud-compute:1.12.1")
     testImplementation("org.apache.commons:commons-lang3:3.12.0")
     testImplementation("io.mockk:mockk:1.13.2")
+    testImplementation("io.github.cdklabs:projen:0.63.25")
 }
 
 tasks.test {

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/TestUtils.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/TestUtils.kt
@@ -2,7 +2,12 @@ package com.virtuslab.pulumikotlin
 
 import com.pulumi.core.Output
 import com.virtuslab.pulumikotlin.codegen.step2intermediate.PulumiNamingConfiguration
+import io.github.cdklabs.projen.java.JavaProject
+import io.github.cdklabs.projen.java.JavaProjectOptions
 import org.junit.jupiter.api.Assertions.assertFalse
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 internal fun <T> extractOutputValue(output: Output<T>?): T? {
     var value: T? = null
@@ -11,7 +16,7 @@ internal fun <T> extractOutputValue(output: Output<T>?): T? {
 }
 
 internal fun <T> concat(iterableOfIterables: Iterable<Iterable<T>>?): List<T> =
-    iterableOfIterables?.flatten() ?: emptyList()
+    iterableOfIterables?.flatten().orEmpty()
 
 internal fun <T> concat(vararg iterables: Iterable<T>?): List<T> =
     concat(iterables.filterNotNull().asIterable())
@@ -29,4 +34,62 @@ internal fun <T> assertDoesNotContain(iterable: Iterable<T>, element: T, message
             Collection <$iterable>, element <$element>.
         """.trimIndent()
     }
+}
+
+private fun getFileDirectoryForFilePackage(file: File): String {
+    val packageString = file.readLines()
+        .firstOrNull { it.startsWith("package") }
+        ?.removePrefix("package")
+        ?.removeSuffix(";")
+        ?.trim()
+
+    return packageString?.replace(".", "/") ?: "com/main"
+}
+
+private fun organizeFilesAccordingToTheirPackage(filesToOrganize: List<File>, outputDirectory: File) {
+    filesToOrganize.forEach { file ->
+        val relativeDirectory = getFileDirectoryForFilePackage(file)
+        val absoluteDirectory = File(outputDirectory, relativeDirectory)
+        val absoluteTargetFile = File(absoluteDirectory, file.name)
+        absoluteDirectory.mkdirs()
+        file.copyTo(absoluteTargetFile)
+    }
+}
+
+internal fun ejectToMavenProject(dependencies: List<String>, directoriesOrFiles: List<File>, testName: String? = null) {
+    val formattedTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss"))
+    val preparedTestName = testName?.let {
+        val withEscapedChars = it.replace(Regex(" +"), "-").replace(Regex("[^a-zA-Z0-9-]"), "")
+        "$withEscapedChars-"
+    } ?: ""
+
+    val ejectedProjectName = "test-$preparedTestName$formattedTime"
+    val outputDirectoryBase = "ejected-tests/$ejectedProjectName"
+
+    val project = JavaProject(
+        JavaProjectOptions.builder()
+            .artifactId(ejectedProjectName)
+            .groupId("com.virtuslab")
+            .name(ejectedProjectName)
+            .version("1.0.0")
+            .projenrcJava(true)
+            .deps(dependencies.map { it.replaceFirst(":", "/").replace(":", "@") })
+            .outdir(outputDirectoryBase)
+            .build(),
+    )
+
+    println("Ejecting project to $outputDirectoryBase...")
+    project.synth()
+
+    val filesToOrganize = directoriesOrFiles.flatMap { listFilesRecursively(it) }
+    val outputDirectory = File(outputDirectoryBase).resolve("src/main/java")
+    organizeFilesAccordingToTheirPackage(filesToOrganize, outputDirectory)
+}
+
+fun listFilesRecursively(directory: File): List<File> {
+    require(directory.isDirectory) { "Expected directory (got: $directory)" }
+    val files = directory.listFiles()?.toList().orEmpty()
+    val filesFoundRecursively = files.filter { it.isDirectory }.flatMap { listFilesRecursively(it) }
+    val filesFoundInCurrentDir = files.filter { it.isFile }
+    return filesFoundInCurrentDir + filesFoundRecursively
 }


### PR DESCRIPTION
## Task

Resolves: None.

## Description

After this is merged, all failed tests in `CodegenTest` will cause maven project to be created under `ejected-tests/test-{{test-name}}-{{time}}`. This maven project and be imported to IntelliJ and significantly increases productivity while fighting bugs.


![Screenshot 2022-10-27 at 15 32 48](https://user-images.githubusercontent.com/4415632/198298595-ff6a4f42-b17c-40a3-b287-ed51dd9b4978.png)

## To do

- [x] handle null properly (example bad name: `test-null2022-10-31T15-15-40`)
