### PR TITLE
Parse the whole schema

### DIFF
--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step1schemaparse/Decoder.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step1schemaparse/Decoder.kt
@@ -1,45 +1,33 @@
 package com.virtuslab.pulumikotlin.codegen.step1schemaparse
 
-import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.Metadata
-import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.PackageLanguage
+import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.RawFullProviderSchema
+import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.Schema
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonObject
 import java.io.InputStream
 
 object Decoder {
     private val KNOWN_TYPE_DUPLICATES = setOf("azure-native:network:IpAllocationMethod")
 
-    fun decode(inputStream: InputStream): ParsedSchema {
-        val schema = Json.parseToJsonElement(inputStream.bufferedReader().readText())
+    fun decode(inputStream: InputStream): Schema {
+        val rawFullProviderSchema =
+            Json.decodeFromString<RawFullProviderSchema>(inputStream.bufferedReader().readText())
 
-        val providerName = requireNotNull(schema.decodeObject<String>("name")) {
-            "Property \"name\" is not present in schema."
+        return with(rawFullProviderSchema) {
+            Schema(
+                providerName = name,
+                providerDisplayName = displayName,
+                description = description,
+                config = config,
+                provider = provider,
+                types = withoutKnownTypeDuplicates(types),
+                functions = functions,
+                resources = resources,
+                metadata = meta,
+                providerLanguage = language,
+            )
         }
-        val types: TypesMap = schema.decodeMap("types")
-        val functions: FunctionsMap = schema.decodeMap("functions")
-        val resources: ResourcesMap = schema.decodeMap("resources")
-        val metadata: Metadata? = schema.decodeObject("meta")
-        val packageLanguage: PackageLanguage? = schema.decodeObject("language")
-
-        return ParsedSchema(
-            providerName,
-            withoutKnownTypeDuplicates(types),
-            functions,
-            resources,
-            metadata,
-            packageLanguage,
-        )
     }
-
-    private inline fun <reified K, reified V> JsonElement.decodeMap(key: String): Map<K, V> =
-        jsonObject[key]
-            ?.let { Json.decodeFromJsonElement<Map<K, V>>(it) }
-            .orEmpty()
-
-    private inline fun <reified T> JsonElement.decodeObject(propertyName: String): T? =
-        jsonObject[propertyName]?.let { Json.decodeFromJsonElement<T>(it) }
 
     private fun withoutKnownTypeDuplicates(types: TypesMap) = types.filterKeys { !KNOWN_TYPE_DUPLICATES.contains(it) }
 }

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step1schemaparse/Extensions.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step1schemaparse/Extensions.kt
@@ -1,7 +1,0 @@
-package com.virtuslab.pulumikotlin.codegen.step1schemaparse
-
-val SchemaModel.ReferenceProperty.referencedTypeName: String
-    get() = ref.referencedTypeName
-
-val SchemaModel.SpecificationReference.referencedTypeName: String
-    get() = value.removePrefix("#/types/")

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/ReferenceFinder.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/ReferenceFinder.kt
@@ -1,6 +1,5 @@
 package com.virtuslab.pulumikotlin.codegen.step2intermediate
 
-import com.virtuslab.pulumikotlin.codegen.step1schemaparse.ParsedSchema
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.ArrayProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.MapProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.ObjectProperty
@@ -10,10 +9,8 @@ import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.Property
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.ReferenceProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.ReferencingOtherTypesProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.RootTypeProperty
+import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.Schema
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.StringEnumProperty
-import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.isArchive
-import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.isAssetOrArchive
-import com.virtuslab.pulumikotlin.codegen.step1schemaparse.referencedTypeName
 import com.virtuslab.pulumikotlin.codegen.step2intermediate.Depth.Nested
 import com.virtuslab.pulumikotlin.codegen.step2intermediate.Direction.Input
 import com.virtuslab.pulumikotlin.codegen.step2intermediate.Direction.Output
@@ -21,7 +18,7 @@ import com.virtuslab.pulumikotlin.codegen.step2intermediate.Subject.Function
 import com.virtuslab.pulumikotlin.codegen.step2intermediate.Subject.Resource
 import com.virtuslab.pulumikotlin.codegen.utils.valuesToSet
 
-class ReferenceFinder(schema: ParsedSchema) {
+class ReferenceFinder(schema: Schema) {
 
     private val rootTypesByName = schema.types.lowercaseKeys()
     private val usages = findAllUsages(schema)
@@ -34,7 +31,7 @@ class ReferenceFinder(schema: ParsedSchema) {
         return usages[typeName].orEmpty()
     }
 
-    private fun findAllUsages(schema: ParsedSchema): Map<String, Set<UsageKind>> {
+    private fun findAllUsages(schema: Schema): Map<String, Set<UsageKind>> {
         val cases = concat(
             findNestedUsages(schema.resources, UsageKind(Nested, Resource, Output)) {
                 it.properties.values
@@ -85,9 +82,7 @@ class ReferenceFinder(schema: ParsedSchema) {
                 getInnerTypesOf(property).flatMap { findReferencedTypeNamesUsedByProperty(it) }
             }
 
-            is PrimitiveProperty -> emptyList()
-            is StringEnumProperty -> emptyList()
-            null -> emptyList()
+            null, is PrimitiveProperty, is StringEnumProperty -> emptyList()
         }
     }
 

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScript.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScript.kt
@@ -18,7 +18,6 @@ import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.Property
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.ReferenceProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.ReferencingOtherTypesProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.StringEnumProperty
-import com.virtuslab.pulumikotlin.codegen.step1schemaparse.referencedTypeName
 import com.virtuslab.pulumikotlin.codegen.step2intermediate.transformKeys
 import com.virtuslab.pulumikotlin.codegen.utils.filterNotNullValues
 import com.virtuslab.pulumikotlin.codegen.utils.shorten

--- a/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/IntermediateRepresentationGeneratorTest.kt
+++ b/src/test/kotlin/com/virtuslab/pulumikotlin/codegen/step2intermediate/IntermediateRepresentationGeneratorTest.kt
@@ -1,13 +1,13 @@
 package com.virtuslab.pulumikotlin.codegen.step2intermediate
 
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.FunctionsMap
-import com.virtuslab.pulumikotlin.codegen.step1schemaparse.ParsedSchema
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.ResourcesMap
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.IntegerProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.ObjectProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.PropertyName
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.ReferenceProperty
+import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.Schema
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.SpecificationReference
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.StringProperty
 import com.virtuslab.pulumikotlin.codegen.step1schemaparse.TypesMap
@@ -406,13 +406,17 @@ internal class IntermediateRepresentationGeneratorTest {
         meta: SchemaModel.Metadata? = getMetaWithSlashInModuleFormat(),
         language: SchemaModel.PackageLanguage? = null,
     ) = IntermediateRepresentationGenerator.getIntermediateRepresentation(
-        ParsedSchema(
+        Schema(
             providerName = providerName,
             types = types,
             resources = resources,
             functions = functions,
-            meta = meta,
-            language = language,
+            metadata = meta,
+            providerLanguage = language,
+            config = null,
+            description = null,
+            providerDisplayName = null,
+            provider = null,
         ),
     )
 


### PR DESCRIPTION
## Task

Resolves: #105, #61

## Description

### 1. Add common fields to `Property` (interface)

Make common property's fields a part of the `Property` sealed interface:

```kt
    sealed interface Property {
        val description: String?
        val default: JsonElement?
        val defaultInfo: JsonElement?
        val deprecationMessage: String?
        val deprecationMessage: String?
        val description: String?
        val language: Language?
        val secret: Boolean
        val const: JsonElement?
        val willReplaceOnChanges: Boolean
        val replaceOnChanges: Boolean
    }
```


### 2. Add missing fields

Add all missing schema fields and use `JsonElement` type if we don't care about that value. 

There are two notable examples.

- `liftSingleValueMethodReturns` (in `language.java`) – not yet sure what this means. It was not present in the docs, but I found this in some schemas. 
- `replaceOnChanges` (field of the property) – we only have interpreted `willReplaceOnChanges` so far, but it turns out these might differ a bit (+ `willReplaceOnChanges` is not documented despite being used everywhere).

### 3. Decode the whole schema, not field by field

In `Decoder.kt`:

```kt
// ...
            Json.decodeFromString<RawFullProviderSchema>(inputStream.bufferedReader().readText())
// ...
```

### 4. Enum values

Enum value needs to be of generic type (`JsonElement` for now). For example, `pulumiservice` has this type with non-string enum values:

```json
{
    "pulumiservice:index:TeamStackPermissionScope": {
      "type": "number",
      "enum": [
        {
          "name": "read",
          "description": "Grants read permissions to stack.",
          "value": 101
        },
        {
          "name": "edit",
          "description": "Grants edit permissions to stack.",
          "value": 102
        },
        {
          "name": "admin",
          "description": "Grants admin permissions to stack.",
          "value": 103
        }
      ]
    }
}
```

## To do

- [x] handle `alicloud` type duplicate (situation similar to `azure-native:network:IpAllocationMethod`) - will probably do in a separate PRs
   - Update: task added #113
- [x] add task for handling `language.java.liftSingleValueMethodReturns`
   - Update: task added #111
- [x] add task for handling `replaceOnChanges`
   - Update: task added #112