### PR TITLE
Improve generator so that slightly more readable code is produced

### DIFF
--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/expressions/Expressions.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/expressions/Expressions.kt
@@ -113,10 +113,10 @@ data class ConstructObjectExpression(val typeName: TypeName, val fields: Map<Str
             .map { (name, value) ->
                 CustomExpressionBuilder.start("%N", name) + "=" + value
             }
-            .reduceOrNull { left, right -> left + "," + right }
+            .reduceOrNull { left, right -> left + ",\n" + right }
             ?: CustomExpressionBuilder.start()
 
-        val builder = CustomExpressionBuilder.start("%T", typeName) + "(" + fieldsBuilder + ")"
+        val builder = CustomExpressionBuilder.start("%T", typeName) + "(\n" + fieldsBuilder + "\n)"
         return builder.build().toCodeBlock()
     }
 }

--- a/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/types/ToJava.kt
+++ b/src/main/kotlin/com/virtuslab/pulumikotlin/codegen/step3codegen/types/ToJava.kt
@@ -25,7 +25,7 @@ object ToJava {
     fun toJavaFunction(typeMetadata: TypeMetadata, fields: List<Field<*>>): FunSpec {
         val codeBlocks = fields.map { field ->
             val block = CodeBlock.of(
-                ".%N(%N)",
+                "\n.%N(%N)",
                 KeywordsEscaper.escape(field.name),
                 field.name,
             )


### PR DESCRIPTION
## Task

Resolves: None

## Description

Improve generator so that slightly more readable code is produced.

## Example

### Before

Something similar to:

```kt
SomeGenerateClass.builder().field1(value1).field1(value1).field1(value1).field1(value1).field1(value1).field1(value1).build()
```


### After 

Something similar to: 

```kt
SomeGenerateClass.builder()
   .field1(value1)
   .field1(value1)
   .field1(value1)
   .field1(value1)
   .field1(value1)
   .field1(value1)
   .build()
```
