### PR TITLE
Add support for provider to `ComputeSchemaSubsetScript`

### DIFF
--- a/src/test/resources/schema-aws-classic-5.16.2-subset-with-provider-and-some-types.json
+++ b/src/test/resources/schema-aws-classic-5.16.2-subset-with-provider-and-some-types.json
@@ -1,0 +1,3969 @@
+{
+  "name": "aws",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "config": {
+    "variables": {
+      "accessKey": {
+        "type": "string",
+        "description": "The access key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.\n"
+      },
+      "allowedAccountIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "assumeRole": {
+        "$ref": "#/types/aws:config/assumeRole:assumeRole"
+      },
+      "assumeRoleWithWebIdentity": {
+        "$ref": "#/types/aws:config/assumeRoleWithWebIdentity:assumeRoleWithWebIdentity"
+      },
+      "customCaBundle": {
+        "type": "string",
+        "description": "File containing custom root and intermediate certificates. Can also be configured using the `AWS_CA_BUNDLE` environment\nvariable. (Setting `ca_bundle` in the shared config file is not supported.)\n"
+      },
+      "defaultTags": {
+        "$ref": "#/types/aws:config/defaultTags:defaultTags",
+        "description": "Configuration block with settings to default resource tags across all resources.\n"
+      },
+      "ec2MetadataServiceEndpoint": {
+        "type": "string",
+        "description": "Address of the EC2 metadata service endpoint to use. Can also be configured using the\n`AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.\n"
+      },
+      "ec2MetadataServiceEndpointMode": {
+        "type": "string",
+        "description": "Protocol to use with EC2 metadata service endpoint.Valid values are `IPv4` and `IPv6`. Can also be configured using the\n`AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.\n"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws:config/endpoints:endpoints"
+        }
+      },
+      "forbiddenAccountIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "httpProxy": {
+        "type": "string",
+        "description": "The address of an HTTP proxy to use when accessing the AWS API. Can also be configured using the `HTTP_PROXY` or\n`HTTPS_PROXY` environment variables.\n"
+      },
+      "ignoreTags": {
+        "$ref": "#/types/aws:config/ignoreTags:ignoreTags",
+        "description": "Configuration block with settings to ignore resource tags across all resources.\n"
+      },
+      "insecure": {
+        "type": "boolean",
+        "description": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted, default value is `false`\n"
+      },
+      "maxRetries": {
+        "type": "integer",
+        "description": "The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.\n"
+      },
+      "profile": {
+        "type": "string",
+        "description": "The profile for API operations. If not set, the default profile created with `aws configure` will be used.\n"
+      },
+      "region": {
+        "type": "string",
+        "$ref": "#/types/aws:index/region:Region",
+        "description": "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.\n",
+        "defaultInfo": {
+          "environment": [
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION"
+          ]
+        }
+      },
+      "s3ForcePathStyle": {
+        "type": "boolean",
+        "description": "Set this to true to enable the request to use path-style addressing, i.e., https://s3.amazonaws.com/BUCKET/KEY. By\ndefault, the S3 client will use virtual hosted bucket addressing when possible (https://BUCKET.s3.amazonaws.com/KEY).\nSpecific to the Amazon S3 service.\n",
+        "deprecationMessage": "Use s3_use_path_style instead."
+      },
+      "s3UsePathStyle": {
+        "type": "boolean",
+        "description": "Set this to true to enable the request to use path-style addressing, i.e., https://s3.amazonaws.com/BUCKET/KEY. By\ndefault, the S3 client will use virtual hosted bucket addressing when possible (https://BUCKET.s3.amazonaws.com/KEY).\nSpecific to the Amazon S3 service.\n"
+      },
+      "secretKey": {
+        "type": "string",
+        "description": "The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.\n"
+      },
+      "sharedConfigFiles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of paths to shared config files. If not set, defaults to [~/.aws/config].\n"
+      },
+      "sharedCredentialsFile": {
+        "type": "string",
+        "description": "The path to the shared credentials file. If not set, defaults to ~/.aws/credentials.\n",
+        "deprecationMessage": "Use shared_credentials_files instead."
+      },
+      "sharedCredentialsFiles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of paths to shared credentials files. If not set, defaults to [~/.aws/credentials].\n"
+      },
+      "skipCredentialsValidation": {
+        "type": "boolean",
+        "description": "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS\navailable/implemented.\n",
+        "default": false
+      },
+      "skipGetEc2Platforms": {
+        "type": "boolean",
+        "description": "Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.\n",
+        "default": true
+      },
+      "skipMetadataApiCheck": {
+        "type": "boolean",
+        "description": "Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.\n",
+        "default": true
+      },
+      "skipRegionValidation": {
+        "type": "boolean",
+        "description": "Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are\nnot public (yet).\n",
+        "default": true
+      },
+      "skipRequestingAccountId": {
+        "type": "boolean",
+        "description": "Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.\n"
+      },
+      "stsRegion": {
+        "type": "string",
+        "description": "The region where AWS STS operations will take place. Examples are us-east-1 and us-west-2.\n"
+      },
+      "token": {
+        "type": "string",
+        "description": "session token. A session token is only required if you are using temporary security credentials.\n"
+      },
+      "useDualstackEndpoint": {
+        "type": "boolean",
+        "description": "Resolve an endpoint with DualStack capability\n"
+      },
+      "useFipsEndpoint": {
+        "type": "boolean",
+        "description": "Resolve an endpoint with FIPS capability\n"
+      }
+    }
+  },
+  "language": {
+    "csharp": {
+      "compatibility": "tfbridge20",
+      "namespaces": {
+        "accessanalyzer": "AccessAnalyzer",
+        "account": "Account",
+        "acm": "Acm",
+        "acmpca": "Acmpca",
+        "alb": "Alb",
+        "amp": "Amp",
+        "amplify": "Amplify",
+        "apigateway": "ApiGateway",
+        "apigatewayv2": "ApiGatewayV2",
+        "appautoscaling": "AppAutoScaling",
+        "appconfig": "AppConfig",
+        "appflow": "AppFlow",
+        "applicationinsights": "ApplicationInsights",
+        "applicationloadbalancing": "ApplicationLoadBalancing",
+        "appmesh": "AppMesh",
+        "apprunner": "AppRunner",
+        "appstream": "AppStream",
+        "appsync": "AppSync",
+        "athena": "Athena",
+        "autoscaling": "AutoScaling",
+        "autoscalingplans": "AutoScalingPlans",
+        "aws": "Aws",
+        "backup": "Backup",
+        "batch": "Batch",
+        "budgets": "Budgets",
+        "cfg": "Cfg",
+        "chime": "Chime",
+        "cloud9": "Cloud9",
+        "cloudcontrol": "CloudControl",
+        "cloudformation": "CloudFormation",
+        "cloudfront": "CloudFront",
+        "cloudhsmv2": "CloudHsmV2",
+        "cloudsearch": "CloudSearch",
+        "cloudtrail": "CloudTrail",
+        "cloudwatch": "CloudWatch",
+        "codeartifact": "CodeArtifact",
+        "codebuild": "CodeBuild",
+        "codecommit": "CodeCommit",
+        "codedeploy": "CodeDeploy",
+        "codepipeline": "CodePipeline",
+        "codestarconnections": "CodeStarConnections",
+        "codestarnotifications": "CodeStarNotifications",
+        "cognito": "Cognito",
+        "comprehend": "Comprehend",
+        "connect": "Connect",
+        "costexplorer": "CostExplorer",
+        "cur": "Cur",
+        "dataexchange": "DataExchange",
+        "datapipeline": "DataPipeline",
+        "datasync": "DataSync",
+        "dax": "Dax",
+        "detective": "Detective",
+        "devicefarm": "DeviceFarm",
+        "directconnect": "DirectConnect",
+        "directoryservice": "DirectoryService",
+        "dlm": "Dlm",
+        "dms": "Dms",
+        "docdb": "DocDB",
+        "dynamodb": "DynamoDB",
+        "ebs": "Ebs",
+        "ec2": "Ec2",
+        "ec2clientvpn": "Ec2ClientVpn",
+        "ec2transitgateway": "Ec2TransitGateway",
+        "ecr": "Ecr",
+        "ecrpublic": "EcrPublic",
+        "ecs": "Ecs",
+        "efs": "Efs",
+        "eks": "Eks",
+        "elasticache": "ElastiCache",
+        "elasticbeanstalk": "ElasticBeanstalk",
+        "elasticloadbalancing": "ElasticLoadBalancing",
+        "elasticloadbalancingv2": "ElasticLoadBalancingV2",
+        "elasticsearch": "ElasticSearch",
+        "elastictranscoder": "ElasticTranscoder",
+        "elb": "Elb",
+        "emr": "Emr",
+        "emrcontainers": "EmrContainers",
+        "emrserverless": "EmrServerless",
+        "fis": "Fis",
+        "fms": "Fms",
+        "fsx": "Fsx",
+        "gamelift": "GameLift",
+        "glacier": "Glacier",
+        "globalaccelerator": "GlobalAccelerator",
+        "glue": "Glue",
+        "grafana": "Grafana",
+        "guardduty": "GuardDuty",
+        "iam": "Iam",
+        "identitystore": "IdentityStore",
+        "imagebuilder": "ImageBuilder",
+        "index": "index",
+        "inspector": "Inspector",
+        "iot": "Iot",
+        "kendra": "Kendra",
+        "keyspaces": "Keyspaces",
+        "kinesis": "Kinesis",
+        "kinesisanalyticsv2": "KinesisAnalyticsV2",
+        "kms": "Kms",
+        "lakeformation": "LakeFormation",
+        "lambda": "Lambda",
+        "lb": "LB",
+        "lex": "Lex",
+        "licensemanager": "LicenseManager",
+        "lightsail": "LightSail",
+        "location": "Location",
+        "macie": "Macie",
+        "macie2": "Macie2",
+        "mediaconvert": "MediaConvert",
+        "medialive": "MediaLive",
+        "mediapackage": "MediaPackage",
+        "mediastore": "MediaStore",
+        "memorydb": "MemoryDb",
+        "mq": "Mq",
+        "msk": "Msk",
+        "mskconnect": "MskConnect",
+        "mwaa": "Mwaa",
+        "neptune": "Neptune",
+        "networkfirewall": "NetworkFirewall",
+        "networkmanager": "NetworkManager",
+        "opensearch": "OpenSearch",
+        "opsworks": "OpsWorks",
+        "organizations": "Organizations",
+        "outposts": "Outposts",
+        "pinpoint": "Pinpoint",
+        "pricing": "Pricing",
+        "qldb": "Qldb",
+        "quicksight": "Quicksight",
+        "ram": "Ram",
+        "rds": "Rds",
+        "redshift": "RedShift",
+        "redshiftdata": "RedshiftData",
+        "redshiftserverless": "RedshiftServerless",
+        "resourcegroups": "ResourceGroups",
+        "resourcegroupstaggingapi": "ResourceGroupsTaggingApi",
+        "rolesanywhere": "RolesAnywhere",
+        "route53": "Route53",
+        "route53domains": "Route53Domains",
+        "route53recoverycontrol": "Route53RecoveryControl",
+        "route53recoveryreadiness": "Route53RecoveryReadiness",
+        "rum": "Rum",
+        "s3": "S3",
+        "s3control": "S3Control",
+        "s3outposts": "S3Outposts",
+        "sagemaker": "Sagemaker",
+        "schemas": "Schemas",
+        "secretsmanager": "SecretsManager",
+        "securityhub": "SecurityHub",
+        "serverlessrepository": "ServerlessRepository",
+        "servicecatalog": "ServiceCatalog",
+        "servicediscovery": "ServiceDiscovery",
+        "servicequotas": "ServiceQuotas",
+        "ses": "Ses",
+        "sfn": "Sfn",
+        "shield": "Shield",
+        "signer": "Signer",
+        "simpledb": "SimpleDB",
+        "sns": "Sns",
+        "sqs": "Sqs",
+        "ssm": "Ssm",
+        "ssoadmin": "SsoAdmin",
+        "storagegateway": "StorageGateway",
+        "swf": "Swf",
+        "synthetics": "Synthetics",
+        "timestreamwrite": "TimestreamWrite",
+        "transcribe": "Transcribe",
+        "transfer": "Transfer",
+        "waf": "Waf",
+        "wafregional": "WafRegional",
+        "wafv2": "WafV2",
+        "worklink": "WorkLink",
+        "workspaces": "Workspaces",
+        "xray": "Xray"
+      },
+      "packageReferences": {
+        "Pulumi": "3.*"
+      }
+    },
+    "go": {
+      "generateExtraInputTypes": true,
+      "generateResourceContainerTypes": true,
+      "importBasePath": "github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
+    },
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-sdk": "^2.0.0",
+        "builtin-modules": "3.0.0",
+        "mime": "^2.0.0",
+        "read-package-tree": "^5.2.1",
+        "resolve": "^1.7.1"
+      },
+      "devDependencies": {
+        "@types/mime": "^2.0.0",
+        "@types/node": "^10.0.0"
+      },
+      "disableUnionOutputTypes": true,
+      "packageDescription": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
+      "packageName": "",
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-aws)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-aws` repo](https://github.com/pulumi/pulumi-aws/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-aws` repo](https://github.com/hashicorp/terraform-provider-aws/issues).",
+      "typescriptVersion": ""
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-aws)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-aws` repo](https://github.com/pulumi/pulumi-aws/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-aws` repo](https://github.com/hashicorp/terraform-provider-aws/issues).",
+      "requires": {
+        "pulumi": ">=3.0.0,<4.0.0"
+      }
+    }
+  },
+  "provider": {
+    "description": "The provider type for the aws package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n",
+    "properties": {
+      "accessKey": {
+        "type": "string",
+        "description": "The access key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.\n"
+      },
+      "allowedAccountIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "assumeRole": {
+        "$ref": "#/types/aws:index/ProviderAssumeRole:ProviderAssumeRole"
+      },
+      "assumeRoleWithWebIdentity": {
+        "$ref": "#/types/aws:index/ProviderAssumeRoleWithWebIdentity:ProviderAssumeRoleWithWebIdentity"
+      },
+      "customCaBundle": {
+        "type": "string",
+        "description": "File containing custom root and intermediate certificates. Can also be configured using the `AWS_CA_BUNDLE` environment\nvariable. (Setting `ca_bundle` in the shared config file is not supported.)\n"
+      },
+      "defaultTags": {
+        "$ref": "#/types/aws:index/ProviderDefaultTags:ProviderDefaultTags",
+        "description": "Configuration block with settings to default resource tags across all resources.\n"
+      },
+      "ec2MetadataServiceEndpoint": {
+        "type": "string",
+        "description": "Address of the EC2 metadata service endpoint to use. Can also be configured using the\n`AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.\n"
+      },
+      "ec2MetadataServiceEndpointMode": {
+        "type": "string",
+        "description": "Protocol to use with EC2 metadata service endpoint.Valid values are `IPv4` and `IPv6`. Can also be configured using the\n`AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.\n"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws:index/ProviderEndpoint:ProviderEndpoint"
+        }
+      },
+      "forbiddenAccountIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "httpProxy": {
+        "type": "string",
+        "description": "The address of an HTTP proxy to use when accessing the AWS API. Can also be configured using the `HTTP_PROXY` or\n`HTTPS_PROXY` environment variables.\n"
+      },
+      "ignoreTags": {
+        "$ref": "#/types/aws:index/ProviderIgnoreTags:ProviderIgnoreTags",
+        "description": "Configuration block with settings to ignore resource tags across all resources.\n"
+      },
+      "insecure": {
+        "type": "boolean",
+        "description": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted, default value is `false`\n"
+      },
+      "maxRetries": {
+        "type": "integer",
+        "description": "The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.\n"
+      },
+      "profile": {
+        "type": "string",
+        "description": "The profile for API operations. If not set, the default profile created with `aws configure` will be used.\n"
+      },
+      "region": {
+        "type": "string",
+        "$ref": "#/types/aws:index/region:Region",
+        "description": "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.\n"
+      },
+      "s3ForcePathStyle": {
+        "type": "boolean",
+        "description": "Set this to true to enable the request to use path-style addressing, i.e., https://s3.amazonaws.com/BUCKET/KEY. By\ndefault, the S3 client will use virtual hosted bucket addressing when possible (https://BUCKET.s3.amazonaws.com/KEY).\nSpecific to the Amazon S3 service.\n",
+        "deprecationMessage": "Use s3_use_path_style instead."
+      },
+      "s3UsePathStyle": {
+        "type": "boolean",
+        "description": "Set this to true to enable the request to use path-style addressing, i.e., https://s3.amazonaws.com/BUCKET/KEY. By\ndefault, the S3 client will use virtual hosted bucket addressing when possible (https://BUCKET.s3.amazonaws.com/KEY).\nSpecific to the Amazon S3 service.\n"
+      },
+      "secretKey": {
+        "type": "string",
+        "description": "The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.\n"
+      },
+      "sharedConfigFiles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of paths to shared config files. If not set, defaults to [~/.aws/config].\n"
+      },
+      "sharedCredentialsFile": {
+        "type": "string",
+        "description": "The path to the shared credentials file. If not set, defaults to ~/.aws/credentials.\n",
+        "deprecationMessage": "Use shared_credentials_files instead."
+      },
+      "sharedCredentialsFiles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of paths to shared credentials files. If not set, defaults to [~/.aws/credentials].\n"
+      },
+      "skipCredentialsValidation": {
+        "type": "boolean",
+        "description": "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS\navailable/implemented.\n"
+      },
+      "skipGetEc2Platforms": {
+        "type": "boolean",
+        "description": "Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.\n"
+      },
+      "skipMetadataApiCheck": {
+        "type": "boolean",
+        "description": "Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.\n"
+      },
+      "skipRegionValidation": {
+        "type": "boolean",
+        "description": "Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are\nnot public (yet).\n"
+      },
+      "skipRequestingAccountId": {
+        "type": "boolean",
+        "description": "Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.\n"
+      },
+      "stsRegion": {
+        "type": "string",
+        "description": "The region where AWS STS operations will take place. Examples are us-east-1 and us-west-2.\n"
+      },
+      "token": {
+        "type": "string",
+        "description": "session token. A session token is only required if you are using temporary security credentials.\n"
+      },
+      "useDualstackEndpoint": {
+        "type": "boolean",
+        "description": "Resolve an endpoint with DualStack capability\n"
+      },
+      "useFipsEndpoint": {
+        "type": "boolean",
+        "description": "Resolve an endpoint with FIPS capability\n"
+      }
+    },
+    "inputProperties": {
+      "accessKey": {
+        "type": "string",
+        "description": "The access key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.\n"
+      },
+      "allowedAccountIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "assumeRole": {
+        "$ref": "#/types/aws:index/ProviderAssumeRole:ProviderAssumeRole"
+      },
+      "assumeRoleWithWebIdentity": {
+        "$ref": "#/types/aws:index/ProviderAssumeRoleWithWebIdentity:ProviderAssumeRoleWithWebIdentity"
+      },
+      "customCaBundle": {
+        "type": "string",
+        "description": "File containing custom root and intermediate certificates. Can also be configured using the `AWS_CA_BUNDLE` environment\nvariable. (Setting `ca_bundle` in the shared config file is not supported.)\n"
+      },
+      "defaultTags": {
+        "$ref": "#/types/aws:index/ProviderDefaultTags:ProviderDefaultTags",
+        "description": "Configuration block with settings to default resource tags across all resources.\n"
+      },
+      "ec2MetadataServiceEndpoint": {
+        "type": "string",
+        "description": "Address of the EC2 metadata service endpoint to use. Can also be configured using the\n`AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.\n"
+      },
+      "ec2MetadataServiceEndpointMode": {
+        "type": "string",
+        "description": "Protocol to use with EC2 metadata service endpoint.Valid values are `IPv4` and `IPv6`. Can also be configured using the\n`AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.\n"
+      },
+      "endpoints": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws:index/ProviderEndpoint:ProviderEndpoint"
+        }
+      },
+      "forbiddenAccountIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "httpProxy": {
+        "type": "string",
+        "description": "The address of an HTTP proxy to use when accessing the AWS API. Can also be configured using the `HTTP_PROXY` or\n`HTTPS_PROXY` environment variables.\n"
+      },
+      "ignoreTags": {
+        "$ref": "#/types/aws:index/ProviderIgnoreTags:ProviderIgnoreTags",
+        "description": "Configuration block with settings to ignore resource tags across all resources.\n"
+      },
+      "insecure": {
+        "type": "boolean",
+        "description": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted, default value is `false`\n"
+      },
+      "maxRetries": {
+        "type": "integer",
+        "description": "The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.\n"
+      },
+      "profile": {
+        "type": "string",
+        "description": "The profile for API operations. If not set, the default profile created with `aws configure` will be used.\n"
+      },
+      "region": {
+        "type": "string",
+        "$ref": "#/types/aws:index/region:Region",
+        "description": "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.\n",
+        "defaultInfo": {
+          "environment": [
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION"
+          ]
+        }
+      },
+      "s3ForcePathStyle": {
+        "type": "boolean",
+        "description": "Set this to true to enable the request to use path-style addressing, i.e., https://s3.amazonaws.com/BUCKET/KEY. By\ndefault, the S3 client will use virtual hosted bucket addressing when possible (https://BUCKET.s3.amazonaws.com/KEY).\nSpecific to the Amazon S3 service.\n",
+        "deprecationMessage": "Use s3_use_path_style instead."
+      },
+      "s3UsePathStyle": {
+        "type": "boolean",
+        "description": "Set this to true to enable the request to use path-style addressing, i.e., https://s3.amazonaws.com/BUCKET/KEY. By\ndefault, the S3 client will use virtual hosted bucket addressing when possible (https://BUCKET.s3.amazonaws.com/KEY).\nSpecific to the Amazon S3 service.\n"
+      },
+      "secretKey": {
+        "type": "string",
+        "description": "The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.\n"
+      },
+      "sharedConfigFiles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of paths to shared config files. If not set, defaults to [~/.aws/config].\n"
+      },
+      "sharedCredentialsFile": {
+        "type": "string",
+        "description": "The path to the shared credentials file. If not set, defaults to ~/.aws/credentials.\n",
+        "deprecationMessage": "Use shared_credentials_files instead."
+      },
+      "sharedCredentialsFiles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of paths to shared credentials files. If not set, defaults to [~/.aws/credentials].\n"
+      },
+      "skipCredentialsValidation": {
+        "type": "boolean",
+        "description": "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS\navailable/implemented.\n",
+        "default": false
+      },
+      "skipGetEc2Platforms": {
+        "type": "boolean",
+        "description": "Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.\n",
+        "default": true
+      },
+      "skipMetadataApiCheck": {
+        "type": "boolean",
+        "description": "Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.\n",
+        "default": true
+      },
+      "skipRegionValidation": {
+        "type": "boolean",
+        "description": "Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are\nnot public (yet).\n",
+        "default": true
+      },
+      "skipRequestingAccountId": {
+        "type": "boolean",
+        "description": "Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.\n"
+      },
+      "stsRegion": {
+        "type": "string",
+        "description": "The region where AWS STS operations will take place. Examples are us-east-1 and us-west-2.\n"
+      },
+      "token": {
+        "type": "string",
+        "description": "session token. A session token is only required if you are using temporary security credentials.\n"
+      },
+      "useDualstackEndpoint": {
+        "type": "boolean",
+        "description": "Resolve an endpoint with DualStack capability\n"
+      },
+      "useFipsEndpoint": {
+        "type": "boolean",
+        "description": "Resolve an endpoint with FIPS capability\n"
+      }
+    }
+  },
+  "types": {
+    "aws:fsx/getOpenZfsSnapshotFilter:getOpenZfsSnapshotFilter": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the snapshot.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "values"
+      ]
+    },
+    "aws:index/ProviderAssumeRole:ProviderAssumeRole": {
+      "properties": {
+        "duration": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "durationSeconds": {
+          "type": "integer",
+          "deprecationMessage": "Use assume_role.duration instead",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "externalId": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "policy": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "policyArns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "roleArn": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sessionName": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sourceIdentity": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "transitiveTagKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:index/ProviderAssumeRoleWithWebIdentity:ProviderAssumeRoleWithWebIdentity": {
+      "properties": {
+        "duration": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "policy": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "policyArns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "roleArn": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sessionName": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "webIdentityToken": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "webIdentityTokenFile": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:index/ProviderDefaultTags:ProviderDefaultTags": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:index/ProviderEndpoint:ProviderEndpoint": {
+      "properties": {
+        "accessanalyzer": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "account": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "acm": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "acmpca": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "alexaforbusiness": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "amg": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "amp": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "amplify": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "amplifybackend": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "amplifyuibuilder": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "apigateway": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "apigatewaymanagementapi": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "apigatewayv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appautoscaling": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appconfig": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appconfigdata": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appflow": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appintegrations": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appintegrationsservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "applicationautoscaling": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "applicationcostprofiler": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "applicationdiscovery": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "applicationdiscoveryservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "applicationinsights": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appmesh": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appregistry": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "apprunner": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appstream": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "appsync": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "athena": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "auditmanager": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "augmentedairuntime": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "autoscaling": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "autoscalingplans": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "backup": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "backupgateway": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "batch": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "beanstalk": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "billingconductor": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "braket": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "budgets": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ce": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "chime": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "chimesdkidentity": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "chimesdkmeetings": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "chimesdkmessaging": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloud9": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudcontrol": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudcontrolapi": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "clouddirectory": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudformation": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudfront": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudhsm": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudhsmv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudsearch": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudsearchdomain": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudtrail": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudwatch": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudwatchevents": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudwatchevidently": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudwatchlog": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudwatchlogs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cloudwatchrum": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codeartifact": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codebuild": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codecommit": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codedeploy": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codeguruprofiler": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codegurureviewer": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codepipeline": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codestar": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codestarconnections": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "codestarnotifications": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cognitoidentity": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cognitoidentityprovider": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cognitoidp": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cognitosync": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "comprehend": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "comprehendmedical": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "computeoptimizer": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "config": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "configservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "connect": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "connectcontactlens": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "connectparticipant": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "connectwisdomservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "costandusagereportservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "costexplorer": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "cur": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "customerprofiles": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "databasemigration": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "databasemigrationservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "databrew": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "dataexchange": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "datapipeline": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "datasync": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "dax": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "deploy": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "detective": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "devicefarm": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "devopsguru": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "directconnect": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "directoryservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "discovery": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "dlm": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "dms": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "docdb": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "drs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ds": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "dynamodb": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "dynamodbstreams": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ebs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ec2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ec2instanceconnect": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ecr": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ecrpublic": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ecs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "efs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "eks": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elasticache": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elasticbeanstalk": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elasticinference": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elasticloadbalancing": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elasticloadbalancingv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elasticsearch": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elasticsearchservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elastictranscoder": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elb": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "elbv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "emr": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "emrcontainers": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "emrserverless": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "es": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "eventbridge": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "events": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "evidently": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "finspace": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "finspacedata": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "firehose": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "fis": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "fms": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "forecast": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "forecastquery": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "forecastqueryservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "forecastservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "frauddetector": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "fsx": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "gamelift": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "glacier": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "globalaccelerator": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "glue": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "gluedatabrew": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "grafana": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "greengrass": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "greengrassv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "groundstation": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "guardduty": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "health": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "healthlake": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "honeycode": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iam": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "identitystore": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "imagebuilder": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "inspector": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "inspector2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iot": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iot1clickdevices": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iot1clickdevicesservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iot1clickprojects": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotanalytics": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotdata": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotdataplane": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotdeviceadvisor": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotevents": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ioteventsdata": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotfleethub": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotjobsdata": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotjobsdataplane": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotsecuretunneling": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotsitewise": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotthingsgraph": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iottwinmaker": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "iotwireless": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ivs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kafka": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kafkaconnect": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kendra": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "keyspaces": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kinesis": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kinesisanalytics": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kinesisanalyticsv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kinesisvideo": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kinesisvideoarchivedmedia": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kinesisvideomedia": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kinesisvideosignaling": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kinesisvideosignalingchannels": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "kms": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lakeformation": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lambda": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lex": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexmodelbuilding": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexmodelbuildingservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexmodels": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexmodelsv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexruntime": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexruntimeservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexruntimev2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexv2models": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lexv2runtime": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "licensemanager": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lightsail": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "location": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "locationservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "logs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lookoutequipment": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lookoutforvision": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lookoutmetrics": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "lookoutvision": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "machinelearning": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "macie": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "macie2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "managedblockchain": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "managedgrafana": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "marketplacecatalog": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "marketplacecommerceanalytics": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "marketplaceentitlement": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "marketplaceentitlementservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "marketplacemetering": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mediaconnect": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mediaconvert": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "medialive": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mediapackage": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mediapackagevod": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mediastore": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mediastoredata": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mediatailor": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "memorydb": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "meteringmarketplace": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mgh": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mgn": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "migrationhub": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "migrationhubconfig": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "migrationhubrefactorspaces": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "migrationhubstrategy": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "migrationhubstrategyrecommendations": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mobile": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mq": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "msk": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mturk": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "mwaa": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "neptune": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "networkfirewall": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "networkmanager": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "nimble": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "nimblestudio": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "opensearch": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "opensearchservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "opsworks": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "opsworkscm": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "organizations": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "outposts": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "panorama": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "personalize": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "personalizeevents": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "personalizeruntime": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "pi": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "pinpoint": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "pinpointemail": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "pinpointsmsvoice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "polly": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "pricing": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "prometheus": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "prometheusservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "proton": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "qldb": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "qldbsession": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "quicksight": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ram": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "rbin": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "rds": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "rdsdata": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "rdsdataservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "recyclebin": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "redshift": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "redshiftdata": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "redshiftdataapiservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "redshiftserverless": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "rekognition": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "resiliencehub": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "resourcegroups": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "resourcegroupstagging": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "resourcegroupstaggingapi": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "robomaker": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "rolesanywhere": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "route53": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "route53domains": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "route53recoverycluster": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "route53recoverycontrolconfig": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "route53recoveryreadiness": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "route53resolver": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "rum": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "s3": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "s3api": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "s3control": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "s3outposts": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sagemaker": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sagemakera2iruntime": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sagemakeredge": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sagemakeredgemanager": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sagemakerfeaturestoreruntime": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sagemakerruntime": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "savingsplans": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "schemas": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sdb": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "secretsmanager": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "securityhub": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "serverlessapplicationrepository": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "serverlessapprepo": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "serverlessrepo": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "servicecatalog": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "servicecatalogappregistry": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "servicediscovery": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "servicequotas": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ses": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sesv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sfn": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "shield": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "signer": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "simpledb": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sms": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "snowball": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "snowdevicemanagement": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sns": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sqs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ssm": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ssmcontacts": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ssmincidents": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sso": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ssoadmin": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "ssooidc": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "stepfunctions": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "storagegateway": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sts": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "support": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "swf": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "synthetics": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "textract": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "timestreamquery": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "timestreamwrite": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "transcribe": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "transcribeservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "transcribestreaming": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "transcribestreamingservice": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "transfer": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "translate": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "voiceid": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "waf": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "wafregional": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "wafv2": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "wellarchitected": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "wisdom": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "workdocs": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "worklink": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "workmail": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "workmailmessageflow": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "workspaces": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "workspacesweb": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "xray": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:index/ProviderIgnoreTags:ProviderIgnoreTags": {
+      "properties": {
+        "keyPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:index/Region:Region": {
+      "description": "A Region represents any valid Amazon region that may be targeted with deployments.",
+      "type": "string",
+      "enum": [
+        {
+          "name": "AFSouth1",
+          "value": "af-south-1"
+        },
+        {
+          "name": "APEast1",
+          "value": "ap-east-1"
+        },
+        {
+          "name": "APNortheast1",
+          "value": "ap-northeast-1"
+        },
+        {
+          "name": "APNortheast2",
+          "value": "ap-northeast-2"
+        },
+        {
+          "name": "APNortheast3",
+          "value": "ap-northeast-3"
+        },
+        {
+          "name": "APSouth1",
+          "value": "ap-south-1"
+        },
+        {
+          "name": "APSoutheast2",
+          "value": "ap-southeast-2"
+        },
+        {
+          "name": "APSoutheast1",
+          "value": "ap-southeast-1"
+        },
+        {
+          "name": "CACentral",
+          "value": "ca-central-1"
+        },
+        {
+          "name": "CNNorth1",
+          "value": "cn-north-1"
+        },
+        {
+          "name": "CNNorthwest1",
+          "value": "cn-northwest-1"
+        },
+        {
+          "name": "EUCentral1",
+          "value": "eu-central-1"
+        },
+        {
+          "name": "EUNorth1",
+          "value": "eu-north-1"
+        },
+        {
+          "name": "EUWest1",
+          "value": "eu-west-1"
+        },
+        {
+          "name": "EUWest2",
+          "value": "eu-west-2"
+        },
+        {
+          "name": "EUWest3",
+          "value": "eu-west-3"
+        },
+        {
+          "name": "EUSouth1",
+          "value": "eu-south-1"
+        },
+        {
+          "name": "MESouth1",
+          "value": "me-south-1"
+        },
+        {
+          "name": "SAEast1",
+          "value": "sa-east-1"
+        },
+        {
+          "name": "USGovEast1",
+          "value": "us-gov-east-1"
+        },
+        {
+          "name": "USGovWest1",
+          "value": "us-gov-west-1"
+        },
+        {
+          "name": "USEast1",
+          "value": "us-east-1"
+        },
+        {
+          "name": "USEast2",
+          "value": "us-east-2"
+        },
+        {
+          "name": "USWest1",
+          "value": "us-west-1"
+        },
+        {
+          "name": "USWest2",
+          "value": "us-west-2"
+        }
+      ]
+    },
+    "aws:lambda/FunctionDeadLetterConfig:FunctionDeadLetterConfig": {
+      "properties": {
+        "targetArn": {
+          "type": "string",
+          "description": "ARN of an SNS topic or SQS queue to notify <<shortened>>RN, depending on which service is targeted.\n",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "targetArn"
+      ]
+    }
+  },
+  "resources": {},
+  "functions": {}
+}


### PR DESCRIPTION
## Task

Resolves: None

## Description

Add `--load-provider-with-children` flag (default value is `true`), so that types referenced in the `provider` section of the schema also appear in the schema subset.
