### PR TITLE
Skip Nomad docs generation

### DIFF
--- a/.github/workflows/pulumi_kotlin.yml
+++ b/.github/workflows/pulumi_kotlin.yml
@@ -72,4 +72,5 @@ jobs:
             -x dokkaPulumiCloudflareJavadoc \
             -x dokkaPulumiGitlabJavadoc \
             -x dokkaPulumiGithubJavadoc \
-            -x dokkaPulumiNomadJavadoc
+            -x dokkaPulumiNomadJavadoc \
+            -x dokkaPulumiDigitaloceanJavadoc


### PR DESCRIPTION
## Task

Resolves: https://github.com/VirtuslabRnD/pulumi-kotlin/issues/124

## Description

I disabled the docs for most providers, since they caused the build to fail on `main`.
