### PR TITLE
Auto-delete disk when VM is removed (examples used in e2e tests)

### DIFF
--- a/examples/gcp-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/gcp-sample-project/src/main/kotlin/project/Main.kt
@@ -12,6 +12,7 @@ fun main() {
                 zone("europe-central2-a")
                 tags("foo", "bar")
                 bootDisk {
+                    autoDelete(true)
                     initializeParams {
                         image("debian-cloud/debian-11")
                     }

--- a/examples/google-native-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/google-native-sample-project/src/main/kotlin/project/Main.kt
@@ -16,6 +16,7 @@ fun main() {
                 disks(
                     {
                         boot(true)
+                        autoDelete(true)
                         initializeParams {
                             sourceImage("projects/debian-cloud/global/images/family/debian-11")
                         }


### PR DESCRIPTION
## Task

Resolves: None.

## Description

I was a bit suspicious about our cloud costs. It turns out that Cloud Storage is to blame. Specifically, disks are not properly cleaned up (removed) after VM instance deletion in e2e tests. 

<img width="1293" alt="Screenshot 2022-11-29 at 16 26 39" src="https://user-images.githubusercontent.com/4415632/204571010-c2a54d64-0928-49a9-832c-13c84541a91f.png">


<img width="1199" alt="Screenshot 2022-11-29 at 16 11 10" src="https://user-images.githubusercontent.com/4415632/204571021-ed26f932-d515-4b77-ac01-6876e49756e9.png">

Solution: GCP needs to be explicitly configured to delete disks (`autoDelete` option, GCP-specific) – kinda makes sense for `autoDelete` to be false by default if you think about the potential data loss. 
By default, it's set to `true` for Google Cloud classic and to `false` for Google Cloud native, that's why you can only see `google-native-sample-project...` disks on the screenshot above.

I'm going to keep removing all the disks in `jvm-lab` project manually until this is merged.



