### PR TITLE
Add `active` label to self hosted workflows

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -31,7 +31,7 @@ jobs:
   publish:
     name: Publish packages
     needs: tag
-    runs-on: self-hosted
+    runs-on: [self-hosted, active]
     if: ${{ needs.tag.outputs.is_release == 'true' }}
     permissions:
       contents: read

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Publish pulumi-kotlin to Maven Local Repository
-    runs-on: self-hosted
+    runs-on: [self-hosted, active]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Task

Related to task [Create autoscaled pool for CI/CD on GCP](https://github.com/VirtuslabRnD/jvm-lab/issues/52) and [corresponding internal PR](https://github.com/VirtuslabRnD/jvm-lab/pull/82). 

## Description

This PR adds label `active` to self-hosted workflows.

This label is used by CI/CD mechanisms on GCP Cloud Functions in order to properly unregister runners and shutdown virtual machines.

Runners with label `active` are protected against deletion when multi-job workflows have still pending jobs and can assign them to a runner.
