### PR TITLE
Update Azure authentication config

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -30,12 +30,12 @@ jobs:
         id: run-azure-e2e-tests
         run: ./gradlew e2eTest --tests AzureE2eTest
         env:
-          # These values were copied from jvm-lab/identity-federation/jplewa-test-2 stack's output
+          # These values were copied from jvm-lab/identity-federation/dev stack's output
           # The Azure tenant/subscription that is used here belongs to @jplewa (Julia Plewa)
-          ARM_TENANT_ID: 'd09acba4-fb14-464d-851a-44a7cf8a064d' # tenant-id output of jvm-lab/identity-federation/jplewa-test-2 stack
-          ARM_SUBSCRIPTION_ID: '46170faf-ef0a-4e4a-af7e-4bf4206045a3' # subscription-id output of jvm-lab/identity-federation/jplewa-test-2 stack
-          ARM_CLIENT_ID: 'd64a493a-c885-4f84-9bee-7faed0df2578' # service-principal-client-id output of jvm-lab/identity-federation/jplewa-test-2 stack
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET_2 }} # This could be done by OIDC, but it's not supported by Pulumi yet (see https://github.com/VirtuslabRnD/pulumi-kotlin/issues/195)
+          ARM_TENANT_ID: 'd09acba4-fb14-464d-851a-44a7cf8a064d' # tenant-id output of jvm-lab/identity-federation/dev stack
+          ARM_SUBSCRIPTION_ID: '46170faf-ef0a-4e4a-af7e-4bf4206045a3' # subscription-id output of jvm-lab/identity-federation/dev stack
+          ARM_CLIENT_ID: 'e4e7a816-ca21-4527-9a57-f5ac641002f2' # service-principal-client-id output of jvm-lab/identity-federation/dev stack
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET }} # This could be done by OIDC, but it's not supported by Pulumi yet (see https://github.com/VirtuslabRnD/pulumi-kotlin/issues/195)
 
           # Pulumi personal access token manually added to `pulumi-kotlin` repo by @myhau (Michal Fudala)
           PULUMI_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_PULUMI }}
@@ -65,12 +65,12 @@ jobs:
         id: run-azure-native-e2e-tests
         run: ./gradlew e2eTest --tests AzureNativeE2eTest
         env:
-          # These values were copied from jvm-lab/identity-federation/jplewa-test-2 stack's output
+          # These values were copied from jvm-lab/identity-federation/dev stack's output
           # The Azure tenant/subscription that is used here belongs to @jplewa (Julia Plewa)
-          ARM_TENANT_ID: 'd09acba4-fb14-464d-851a-44a7cf8a064d' # tenant-id output of jvm-lab/identity-federation/jplewa-test-2 stack
-          ARM_SUBSCRIPTION_ID: '46170faf-ef0a-4e4a-af7e-4bf4206045a3' # subscription-id output of jvm-lab/identity-federation/jplewa-test-2 stack
-          ARM_CLIENT_ID: 'd64a493a-c885-4f84-9bee-7faed0df2578' # service-principal-client-id output of jvm-lab/identity-federation/jplewa-test-2 stack
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET_2 }} # This could be done by OIDC, but it's not supported by Pulumi yet (see https://github.com/VirtuslabRnD/pulumi-kotlin/issues/195)
+          ARM_TENANT_ID: 'd09acba4-fb14-464d-851a-44a7cf8a064d' # tenant-id output of jvm-lab/identity-federation/dev stack
+          ARM_SUBSCRIPTION_ID: '46170faf-ef0a-4e4a-af7e-4bf4206045a3' # subscription-id output of jvm-lab/identity-federation/dev stack
+          ARM_CLIENT_ID: 'e4e7a816-ca21-4527-9a57-f5ac641002f2' # service-principal-client-id output of jvm-lab/identity-federation/dev stack
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET }} # This could be done by OIDC, but it's not supported by Pulumi yet (see https://github.com/VirtuslabRnD/pulumi-kotlin/issues/195)
 
           # Pulumi personal access token manually added to `pulumi-kotlin` repo by @myhau (Michal Fudala)
           PULUMI_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_PULUMI }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./gradlew e2eTest --tests AzureE2eTest
         env:
           # These values were copied from jvm-lab/identity-federation/dev stack's output
-          # The Azure tenant/subscription that is used here belongs to @jplewa (Julia Plewa)
+          # The Azure tenant/subscription that is used here belongs to VirtusLab
           ARM_TENANT_ID: 'd09acba4-fb14-464d-851a-44a7cf8a064d' # tenant-id output of jvm-lab/identity-federation/dev stack
           ARM_SUBSCRIPTION_ID: '46170faf-ef0a-4e4a-af7e-4bf4206045a3' # subscription-id output of jvm-lab/identity-federation/dev stack
           ARM_CLIENT_ID: 'e4e7a816-ca21-4527-9a57-f5ac641002f2' # service-principal-client-id output of jvm-lab/identity-federation/dev stack
@@ -66,7 +66,7 @@ jobs:
         run: ./gradlew e2eTest --tests AzureNativeE2eTest
         env:
           # These values were copied from jvm-lab/identity-federation/dev stack's output
-          # The Azure tenant/subscription that is used here belongs to @jplewa (Julia Plewa)
+          # The Azure tenant/subscription that is used here belongs to VirtusLab
           ARM_TENANT_ID: 'd09acba4-fb14-464d-851a-44a7cf8a064d' # tenant-id output of jvm-lab/identity-federation/dev stack
           ARM_SUBSCRIPTION_ID: '46170faf-ef0a-4e4a-af7e-4bf4206045a3' # subscription-id output of jvm-lab/identity-federation/dev stack
           ARM_CLIENT_ID: 'e4e7a816-ca21-4527-9a57-f5ac641002f2' # service-principal-client-id output of jvm-lab/identity-federation/dev stack

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -30,12 +30,12 @@ jobs:
         id: run-azure-e2e-tests
         run: ./gradlew e2eTest --tests AzureE2eTest
         env:
-          # These values were copied from jvm-lab/identity-federation stack's output
-          # The Azure tenant/subscription that is used here belongs to @myhau (Michal Fudala)
-          ARM_TENANT_ID: '1ff3e4bd-41d1-4df2-b776-8d3fcbf77184' # tenant-id output of jvm-lab/identity-federation/dev stack
-          ARM_SUBSCRIPTION_ID: '3565bcd1-dd9b-45a8-9d7c-8880aaaa9a9f' # subscription-id output of jvm-lab/identity-federation/dev stack
-          ARM_CLIENT_ID: '4169b156-839a-48c2-846f-d7c079331c71' # service-principal-client-id output of jvm-lab/identity-federation/dev stack
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET }} # This could be done by OIDC, but it's not supported by Pulumi yet (see https://github.com/VirtuslabRnD/pulumi-kotlin/issues/195)
+          # These values were copied from jvm-lab/identity-federation/jplewa-test-2 stack's output
+          # The Azure tenant/subscription that is used here belongs to @jplewa (Julia Plewa)
+          ARM_TENANT_ID: 'd09acba4-fb14-464d-851a-44a7cf8a064d' # tenant-id output of jvm-lab/identity-federation/jplewa-test-2 stack
+          ARM_SUBSCRIPTION_ID: '46170faf-ef0a-4e4a-af7e-4bf4206045a3' # subscription-id output of jvm-lab/identity-federation/jplewa-test-2 stack
+          ARM_CLIENT_ID: 'd64a493a-c885-4f84-9bee-7faed0df2578' # service-principal-client-id output of jvm-lab/identity-federation/jplewa-test-2 stack
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET_2 }} # This could be done by OIDC, but it's not supported by Pulumi yet (see https://github.com/VirtuslabRnD/pulumi-kotlin/issues/195)
 
           # Pulumi personal access token manually added to `pulumi-kotlin` repo by @myhau (Michal Fudala)
           PULUMI_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_PULUMI }}
@@ -65,12 +65,12 @@ jobs:
         id: run-azure-native-e2e-tests
         run: ./gradlew e2eTest --tests AzureNativeE2eTest
         env:
-          # These values were copied from jvm-lab/identity-federation stack's output
-          # The Azure tenant/subscription that is used here belongs to @myhau (Michal Fudala)
-          ARM_TENANT_ID: '1ff3e4bd-41d1-4df2-b776-8d3fcbf77184' # tenant-id output of jvm-lab/identity-federation/dev stack
-          ARM_SUBSCRIPTION_ID: '3565bcd1-dd9b-45a8-9d7c-8880aaaa9a9f' # subscription-id output of jvm-lab/identity-federation/dev stack
-          ARM_CLIENT_ID: '4169b156-839a-48c2-846f-d7c079331c71' # service-principal-client-id output of jvm-lab/identity-federation/dev stack
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET }} # This could be done by OIDC, but it's not supported by Pulumi yet (see https://github.com/VirtuslabRnD/pulumi-kotlin/issues/195)
+          # These values were copied from jvm-lab/identity-federation/jplewa-test-2 stack's output
+          # The Azure tenant/subscription that is used here belongs to @jplewa (Julia Plewa)
+          ARM_TENANT_ID: 'd09acba4-fb14-464d-851a-44a7cf8a064d' # tenant-id output of jvm-lab/identity-federation/jplewa-test-2 stack
+          ARM_SUBSCRIPTION_ID: '46170faf-ef0a-4e4a-af7e-4bf4206045a3' # subscription-id output of jvm-lab/identity-federation/jplewa-test-2 stack
+          ARM_CLIENT_ID: 'd64a493a-c885-4f84-9bee-7faed0df2578' # service-principal-client-id output of jvm-lab/identity-federation/jplewa-test-2 stack
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET_2 }} # This could be done by OIDC, but it's not supported by Pulumi yet (see https://github.com/VirtuslabRnD/pulumi-kotlin/issues/195)
 
           # Pulumi personal access token manually added to `pulumi-kotlin` repo by @myhau (Michal Fudala)
           PULUMI_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_PULUMI }}

--- a/examples/azure-native-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/azure-native-sample-project/src/main/kotlin/project/Main.kt
@@ -3,7 +3,7 @@ package project
 import com.pulumi.azurenative.compute.kotlin.enums.CachingTypes.ReadWrite
 import com.pulumi.azurenative.compute.kotlin.enums.DiskCreateOptionTypes.FromImage
 import com.pulumi.azurenative.compute.kotlin.enums.StorageAccountTypes.Standard_LRS
-import com.pulumi.azurenative.compute.kotlin.enums.VirtualMachineSizeTypes.Basic_A0
+import com.pulumi.azurenative.compute.kotlin.enums.VirtualMachineSizeTypes.Standard_B1s
 import com.pulumi.azurenative.compute.kotlin.virtualMachineResource
 import com.pulumi.azurenative.network.kotlin.networkInterfaceResource
 import com.pulumi.azurenative.network.kotlin.subnetResource
@@ -64,7 +64,7 @@ fun main() {
                     }
                 }
                 hardwareProfile {
-                    vmSize(Basic_A0)
+                    vmSize(Standard_B1s)
                 }
                 storageProfile {
                     imageReference {

--- a/examples/azure-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/azure-sample-project/src/main/kotlin/project/Main.kt
@@ -51,7 +51,7 @@ fun main() {
             args {
                 resourceGroupName(resourceGroup.name)
                 networkInterfaceIds(mainNetworkInterface.id)
-                vmSize("Basic_A0")
+                vmSize("Standard_B1s")
                 storageImageReference {
                     publisher("Canonical")
                     offer("UbuntuServer")

--- a/src/e2e/kotlin/com/virtuslab/pulumikotlin/azure/AzureTestUtils.kt
+++ b/src/e2e/kotlin/com/virtuslab/pulumikotlin/azure/AzureTestUtils.kt
@@ -29,7 +29,7 @@ fun getVirtualMachine(virtualMachineId: String): VirtualMachine {
 }
 
 fun assertVmExists(virtualMachine: VirtualMachine) {
-    assertEquals(VirtualMachineSizeTypes.BASIC_A0, virtualMachine.size())
+    assertEquals(VirtualMachineSizeTypes.STANDARD_B1S, virtualMachine.size())
 
     val tags: Map<String, String> = virtualMachine.tags()
     assertContains(tags, "foo")


### PR DESCRIPTION
## Task

Resolves: https://github.com/VirtuslabRnD/jvm-lab/issues/87

## Description

I updated the configuration to run on the VirtusLab Azure subscription. **Note**: the `Basic_A0` VM size was not available for our subscription.

## TODO

- [x] Update `e2e-tests.yml` accordingly once @myhau destroys the `jvm-lab/jvm-lab-identity-federation/dev` stack.