### PR TITLE
Disable Gradle daemon in publications

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -59,7 +59,8 @@ jobs:
             -Psigning.key="${{ secrets.GPG_KEY }}" \
             -Psigning.key.password="${{ secrets.GPG_KEY_PASSWORD }}" \
             -Psonatype.username="${{ secrets.SONATYPE_USERNAME }}" \
-            -Psonatype.password="${{ secrets.SONATYPE_PASSWORD }}"
+            -Psonatype.password="${{ secrets.SONATYPE_PASSWORD }}" \
+            -Dorg.gradle.daemon=false
       - name: Rename Dokka directory before upload
         run: |
           file_name=$(ls ./build/libs/pulumi-${{ matrix.provider }}-*-javadoc.jar | xargs -n 1 basename)

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -25,4 +25,4 @@ jobs:
           distribution: adopt
           java-version: 11
       - name: Publish to Maven Local
-        run: ./gradlew publishPulumi${{ matrix.provider }}PublicationToMavenLocal
+        run: ./gradlew publishPulumi${{ matrix.provider }}PublicationToMavenLocal -Dorg.gradle.daemon=false


### PR DESCRIPTION
## Task

Resolves: None

## Description

This way publications go through (see: https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/4226558228 and https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/4226564812).
