### PR TITLE
Update codegen

### DIFF
--- a/.detekt-config.yml
+++ b/.detekt-config.yml
@@ -6,7 +6,7 @@ output-reports:
     - 'XmlOutputReport'
 
 build:
-  maxIssues: 23 # TODO: Remove this setting after adjusting the codebase to Detekt
+  maxIssues: 24 # TODO: Remove this setting after adjusting the codebase to Detekt
 
 style:
   CanBeNonNullable:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,8 +110,11 @@ tasks["detekt"].dependsOn(tasks["detektE2eTest"])
 
 tasks.register<Task>("prepareReleaseOfUpdatedSchemas") {
     group = "releaseManagement"
+    val skipUnstableVersions = findBooleanProperty("skipUnstableVersions", defaultValue = false)
+    val fastForwardToMostRecentVersion = findBooleanProperty("fastForwardToMostRecentVersion", defaultValue = false)
+
     doLast {
-        updateProviderSchemas(projectDir, versionConfigFile)
+        updateProviderSchemas(projectDir, versionConfigFile, skipUnstableVersions, fastForwardToMostRecentVersion)
     }
 }
 
@@ -178,3 +181,7 @@ if (enableSigning) {
 }
 
 inline fun <reified T> findTypedProperty(propertyString: String): T = findProperty(propertyString) as T
+
+fun findBooleanProperty(propertyName: String, defaultValue: Boolean) = findTypedProperty<String?>(propertyName)
+    ?.toBoolean()
+    ?: defaultValue

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,11 +110,11 @@ tasks["detekt"].dependsOn(tasks["detektE2eTest"])
 
 tasks.register<Task>("prepareReleaseOfUpdatedSchemas") {
     group = "releaseManagement"
-    val skipUnstableVersions = findBooleanProperty("skipUnstableVersions", defaultValue = false)
+    val skipPreReleaseVersions = findBooleanProperty("skipPreReleaseVersions", defaultValue = false)
     val fastForwardToMostRecentVersion = findBooleanProperty("fastForwardToMostRecentVersion", defaultValue = false)
 
     doLast {
-        updateProviderSchemas(projectDir, versionConfigFile, skipUnstableVersions, fastForwardToMostRecentVersion)
+        updateProviderSchemas(projectDir, versionConfigFile, skipPreReleaseVersions, fastForwardToMostRecentVersion)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,31 +17,31 @@ repositories {
 }
 
 dependencies {
-    implementation("com.pulumi:pulumi:0.7.1")
+    implementation("com.pulumi:pulumi:0.9.4")
 
-    implementation("com.squareup:kotlinpoet:1.12.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
+    implementation("com.squareup:kotlinpoet:1.14.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.2")
 
-    implementation("com.github.ajalt.clikt:clikt:3.5.0")
+    implementation("com.github.ajalt.clikt:clikt:3.5.4")
 
     implementation("com.squareup.tools.build:maven-archeologist:0.0.10")
 
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
-    implementation("ch.qos.logback:logback-classic:1.4.5")
+    implementation("ch.qos.logback:logback-classic:1.4.8")
 
     implementation("com.google.code.gson:gson:2.10.1")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
-    testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.4.9")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
+    testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.5.0")
     testImplementation(kotlin("test"))
-    testImplementation("com.google.cloud:google-cloud-compute:1.20.0")
-    testImplementation("com.azure:azure-identity:1.8.0")
-    testImplementation("com.azure.resourcemanager:azure-resourcemanager-compute:2.23.0")
+    testImplementation("com.google.cloud:google-cloud-compute:1.30.0")
+    testImplementation("com.azure:azure-identity:1.9.1")
+    testImplementation("com.azure.resourcemanager:azure-resourcemanager-compute:2.28.0")
 
-    testImplementation("io.kubernetes:client-java:17.0.1")
-    testImplementation("io.mockk:mockk:1.13.4")
-    testImplementation("io.github.cdklabs:projen:0.67.54")
+    testImplementation("io.kubernetes:client-java:18.0.0")
+    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("io.github.cdklabs:projen:0.71.120")
 }
 
 tasks.test {

--- a/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
@@ -1,7 +1,6 @@
 import org.apache.commons.lang3.RandomStringUtils
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.semver4j.Semver
 import java.io.File
@@ -91,7 +90,6 @@ class ReleaseScriptsTest {
     }
 
     @Test
-    @Disabled("Disabled due to unreliable search.maven.org (https://github.com/VirtuslabRnD/pulumi-kotlin/issues/202)")
     fun `updates provider schema versions`() {
         val temporaryGitRepository = File("build/tmp/provider-update-test-${RandomStringUtils.randomAlphanumeric(10)}")
         val beforeUpdateFileName = "before-schema-update.json"

--- a/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
@@ -107,7 +107,7 @@ class ReleaseScriptsTest {
         updateProviderSchemas(
             temporaryGitRepository,
             temporaryBeforeUpdateFile,
-            skipUnstableVersions = false,
+            skipPreReleaseVersions = false,
             fastForwardToMostRecentVersion = false,
         )
 

--- a/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
@@ -1,8 +1,8 @@
 import org.apache.commons.lang3.RandomStringUtils
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import org.semver4j.Semver
 import java.io.File
 import java.nio.file.Files
@@ -104,7 +104,12 @@ class ReleaseScriptsTest {
             beforeUpdateFileName,
         )
 
-        updateProviderSchemas(temporaryGitRepository, temporaryBeforeUpdateFile)
+        updateProviderSchemas(
+            temporaryGitRepository,
+            temporaryBeforeUpdateFile,
+            skipUnstableVersions = false,
+            fastForwardToMostRecentVersion = false,
+        )
 
         assertEquals(
             expectedAfterUpdateFile.readText(),

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -16,7 +16,12 @@ All schema versions used for releasing the libraries are configured in the `src/
 file. There are two release paths:
 
 1. If you want to update provider schemas and build new versions of the libraries, run the Gradle
-   task `prepareReleaseOfUpdatedSchemas`.
+   task `prepareReleaseOfUpdatedSchemas`. This task accepts two boolean arguments:
+  - `skipPreReleaseVersions` - setting this to `true` will skip versions like `4.10.0-alpha.1674847484+ffd6999e` 
+  (**note**: non-stable versions of the format `0.y.z` will not be skipped),
+  - `fastForwardToMostRecentVersion` - if multiple new versions have appeared since our last release 
+  (e.g. `4.13.0`, `4.14.0`, `4.15.0`), setting this to `true` will force `prepareReleaseOfUpdatedSchemas` to use 
+  the most recent one (`4.15.0`).
 2. If you want to release a new version of all libraries due to some update in the generator (i.e. the `pulumi-kotlin`
    codebase), run the Gradle task `prepareReleaseAfterGeneratorUpdate`.
 

--- a/examples/azure-native-sample-project/pom.xml
+++ b/examples/azure-native-sample-project/pom.xml
@@ -22,17 +22,17 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>pulumi</artifactId>
-            <version>0.6.0</version>
+            <version>0.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-azure-native-kotlin</artifactId>
-            <version>1.87.0.0-SNAPSHOT</version>
+            <version>1.103.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-random-kotlin</artifactId>
-            <version>4.6.0.0-SNAPSHOT</version>
+            <version>4.13.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/examples/azure-native-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/azure-native-sample-project/src/main/kotlin/project/Main.kt
@@ -2,6 +2,7 @@ package project
 
 import com.pulumi.azurenative.compute.kotlin.enums.CachingTypes.ReadWrite
 import com.pulumi.azurenative.compute.kotlin.enums.DiskCreateOptionTypes.FromImage
+import com.pulumi.azurenative.compute.kotlin.enums.DiskDeleteOptionTypes
 import com.pulumi.azurenative.compute.kotlin.enums.StorageAccountTypes.Standard_LRS
 import com.pulumi.azurenative.compute.kotlin.enums.VirtualMachineSizeTypes.Standard_B1s
 import com.pulumi.azurenative.compute.kotlin.virtualMachineResource
@@ -80,6 +81,7 @@ fun main() {
                         managedDisk {
                             storageAccountType(Standard_LRS)
                         }
+                        deleteOption(DiskDeleteOptionTypes.Delete)
                     }
                 }
                 osProfile {

--- a/examples/azure-sample-project/pom.xml
+++ b/examples/azure-sample-project/pom.xml
@@ -22,17 +22,17 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>pulumi</artifactId>
-            <version>0.6.0</version>
+            <version>0.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-azure-kotlin</artifactId>
-            <version>5.25.0.0-SNAPSHOT</version>
+            <version>5.44.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-random-kotlin</artifactId>
-            <version>4.6.0.0-SNAPSHOT</version>
+            <version>4.13.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/examples/azure-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/azure-sample-project/src/main/kotlin/project/Main.kt
@@ -73,6 +73,7 @@ fun main() {
                     disablePasswordAuthentication(false)
                 }
                 tags("foo" to "bar")
+                deleteOsDiskOnTermination(true)
             }
         }
         ctx.export("virtualMachineId", virtualMachine.id)

--- a/examples/gcp-provider-sample-project/pom.xml
+++ b/examples/gcp-provider-sample-project/pom.xml
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>pulumi</artifactId>
-            <version>0.6.0</version>
+            <version>0.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-gcp-kotlin</artifactId>
-            <version>6.43.0.0-SNAPSHOT</version>
+            <version>6.59.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/examples/gcp-sample-project/pom.xml
+++ b/examples/gcp-sample-project/pom.xml
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>pulumi</artifactId>
-            <version>0.6.0</version>
+            <version>0.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-gcp-kotlin</artifactId>
-            <version>6.43.0.0-SNAPSHOT</version>
+            <version>6.59.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/examples/google-native-sample-project/pom.xml
+++ b/examples/google-native-sample-project/pom.xml
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>pulumi</artifactId>
-            <version>0.6.0</version>
+            <version>0.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-google-native-kotlin</artifactId>
-            <version>0.27.0.0-SNAPSHOT</version>
+            <version>0.31.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/examples/kubernetes-sample-project/pom.xml
+++ b/examples/kubernetes-sample-project/pom.xml
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>com.pulumi</groupId>
             <artifactId>pulumi</artifactId>
-            <version>0.6.0</version>
+            <version>0.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-kubernetes-kotlin</artifactId>
-            <version>3.22.1.0-SNAPSHOT</version>
+            <version>3.30.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/e2e/kotlin/org/virtuslab/pulumikotlin/Pulumi.kt
+++ b/src/e2e/kotlin/org/virtuslab/pulumikotlin/Pulumi.kt
@@ -1,6 +1,5 @@
 package org.virtuslab.pulumikotlin
 
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import java.io.File
 

--- a/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/step1schemaparse/Decoder.kt
+++ b/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/step1schemaparse/Decoder.kt
@@ -1,6 +1,5 @@
 package org.virtuslab.pulumikotlin.codegen.step1schemaparse
 
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.RawFullProviderSchema
 import org.virtuslab.pulumikotlin.codegen.step1schemaparse.SchemaModel.Schema

--- a/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/step2intermediate/IntermediateRepresentationGenerator.kt
+++ b/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/step2intermediate/IntermediateRepresentationGenerator.kt
@@ -341,10 +341,10 @@ object IntermediateRepresentationGenerator {
             is MapProperty -> MapType(StringType, innerTypeMapper(property.additionalProperties))
             is OneOfProperty -> {
                 val innerTypes = property.oneOf.map { innerTypeMapper(it) }
-                val isFilledWithStringsOnly = innerTypes.all { it is StringType }
+                val isFilledWithOneType = innerTypes.toSet().size == 1
 
-                if (isFilledWithStringsOnly) {
-                    StringType
+                if (isFilledWithOneType) {
+                    innerTypes.first()
                 } else if (innerTypes.size == 2) {
                     EitherType(innerTypes[0], innerTypes[1])
                 } else {

--- a/src/main/kotlin/org/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScript.kt
+++ b/src/main/kotlin/org/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScript.kt
@@ -243,8 +243,9 @@ class ComputeSchemaSubsetScript(outputStream: OutputStream = System.out) : Clikt
         outputPath?.let { File(it).writeText(encodedNewSchema.toString()) } ?: printStream.println(encodedNewSchema)
     }
 
+    @Suppress("HttpUrlsUsage")
     private fun fetchSchemaInputStream(): InputStream =
-        if (fullSchemaPath.startsWith("http")) {
+        if (fullSchemaPath.startsWith("http://") || fullSchemaPath.startsWith("https://")) {
             URL(fullSchemaPath).openStream()
         } else {
             File(fullSchemaPath).inputStream()

--- a/src/main/kotlin/org/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScript.kt
+++ b/src/main/kotlin/org/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScript.kt
@@ -11,7 +11,6 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.transformValues
 import com.github.ajalt.clikt.parameters.types.choice
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -40,8 +39,11 @@ import org.virtuslab.pulumikotlin.scripts.Context.Provider
 import org.virtuslab.pulumikotlin.scripts.Context.Resource
 import org.virtuslab.pulumikotlin.scripts.Context.Type
 import java.io.File
+import java.io.InputStream
 import java.io.OutputStream
 import java.io.PrintStream
+import java.net.URL
+import java.nio.charset.StandardCharsets
 
 fun main(args: Array<String>) {
     ComputeSchemaSubsetScript().main(args)
@@ -81,7 +83,7 @@ class ComputeSchemaSubsetScript(outputStream: OutputStream = System.out) : Clikt
     private val printStream = PrintStream(outputStream)
 
     private val fullSchemaPath: String by option().required().help(
-        "Path to the full schema (can be downloaded from provider's GitHub repository, for example: " +
+        "Path or URL to the full schema (can be downloaded from provider's GitHub repository, for example: " +
             "https://github.com/pulumi/pulumi-gcp/blob/master/provider/cmd/pulumi-resource-gcp/schema.json)",
     )
     private val existingSchemaSubsetPath: String? by option().help(
@@ -153,7 +155,7 @@ class ComputeSchemaSubsetScript(outputStream: OutputStream = System.out) : Clikt
     private val loadFullParents: Boolean by option(help = loadFullParentsHelp).boolean(default = false)
 
     override fun run() {
-        val parsedSchema = Decoder.decode(File(fullSchemaPath).inputStream())
+        val parsedSchema = Decoder.decode(fetchSchemaInputStream())
         val parsedExistingSchema = existingSchemaSubsetPath?.let { Decoder.decode(File(it).inputStream()) }
 
         val providerNameWithContext = NameWithContext("pulumi:providers:${parsedSchema.provider}", Provider)
@@ -217,7 +219,9 @@ class ComputeSchemaSubsetScript(outputStream: OutputStream = System.out) : Clikt
             acc.merge(allTypesThatWereSomehowReferenced)
         }
 
-        val noDataLossSchemaModel = json.decodeFromString<NoDataLossSchemaModel>(File(fullSchemaPath).readText())
+        val noDataLossSchemaModel = json.decodeFromString<NoDataLossSchemaModel>(
+            String(fetchSchemaInputStream().readAllBytes(), StandardCharsets.UTF_8),
+        )
 
         fun <V> getFiltered(map: Map<String, V>, context: Context) =
             map.filterKeys {
@@ -230,7 +234,7 @@ class ComputeSchemaSubsetScript(outputStream: OutputStream = System.out) : Clikt
                 provider = if (loadProviderWithChildren) provider else null,
                 types = getFiltered(types, Type),
                 resources = getFiltered(resources, Resource),
-                functions = getFiltered(functions, Function),
+                functions = functions?.let { getFiltered(it, Function) },
             )
         }
 
@@ -238,6 +242,13 @@ class ComputeSchemaSubsetScript(outputStream: OutputStream = System.out) : Clikt
 
         outputPath?.let { File(it).writeText(encodedNewSchema.toString()) } ?: printStream.println(encodedNewSchema)
     }
+
+    private fun fetchSchemaInputStream(): InputStream =
+        if (fullSchemaPath.startsWith("http")) {
+            URL(fullSchemaPath).openStream()
+        } else {
+            File(fullSchemaPath).inputStream()
+        }
 
     private fun <V> extractProperties(map: Map<String, V>, context: Context, propertyExtractor: (V) -> List<Property>) =
         map
@@ -350,7 +361,7 @@ class ComputeSchemaSubsetScript(outputStream: OutputStream = System.out) : Clikt
 
         return schemaModel.copy(
             types = schemaModel.types.mapValues { removeDescriptionField(it.value) },
-            functions = schemaModel.functions.mapValues { removeDescriptionField(it.value) },
+            functions = schemaModel.functions?.mapValues { removeDescriptionField(it.value) },
             resources = schemaModel.resources.mapValues { removeDescriptionField(it.value) },
         )
     }
@@ -390,7 +401,7 @@ private data class NoDataLossSchemaModel(
     val provider: JsonElement? = null,
     val types: Map<String, JsonElement>,
     val resources: Map<String, JsonElement>,
-    val functions: Map<String, JsonElement>,
+    val functions: Map<String, JsonElement>? = null,
 )
 
 private typealias Name = String

--- a/src/main/resources/version-config-e2e.json
+++ b/src/main/resources/version-config-e2e.json
@@ -1,55 +1,55 @@
 [
   {
     "providerName": "random",
-    "url": "https://raw.githubusercontent.com/pulumi/pulumi-random/v4.6.0/provider/cmd/pulumi-resource-random/schema.json",
-    "kotlinVersion": "4.6.0.0-SNAPSHOT",
-    "javaVersion": "4.6.0",
-    "javaGitTag": "v4.6.0",
+    "url": "https://raw.githubusercontent.com/pulumi/pulumi-random/v4.13.2/provider/cmd/pulumi-resource-random/schema.json",
+    "kotlinVersion": "4.13.2.0-SNAPSHOT",
+    "javaVersion": "4.13.2",
+    "javaGitTag": "v4.13.2",
     "customDependencies": [
     ]
   },
   {
     "providerName": "azure",
-    "url": "https://gist.githubusercontent.com/myhau/cab21c752afb0f7c8e9c8deec82c7c65/raw/850a299b7226547e70df986b096b8d38ef6ebe6d/schema-azure-classic-v5.25.0-subset-for-build.json",
-    "kotlinVersion": "5.25.0.0-SNAPSHOT",
-    "javaVersion": "5.25.0",
-    "javaGitTag": "v5.25.0",
+    "url": "https://gist.githubusercontent.com/jplewa/0897e9ca654d1f029f37162ce8ccba7f/raw/cf5f0801f2c03765316978cf4055be34340346bb/schema-azure-v5.44.1-subset-for-build.json",
+    "kotlinVersion": "5.44.1.0-SNAPSHOT",
+    "javaVersion": "5.44.1",
+    "javaGitTag": "v5.44.1",
     "customDependencies": [
     ]
   },
   {
     "providerName": "azure-native",
-    "url": "https://gist.githubusercontent.com/myhau/00414627dd33a2d3dd5293fe1845562f/raw/76800256b04365af04279af31f377d14c7c6fc84/schema-azure-native-v1.87.0-subset-for-build.json",
-    "kotlinVersion": "1.87.0.0-SNAPSHOT",
-    "javaVersion": "1.87.0",
-    "javaGitTag": "v1.87.0",
+    "url": "https://gist.githubusercontent.com/jplewa/cea43edd61c3284b29c037cd094e0e77/raw/f32ad6c02c8b90efcea1ae10a84a2d92951bab17/schema-azure-native-v1.103.0-subset-for-build.json",
+    "kotlinVersion": "1.103.0.0-SNAPSHOT",
+    "javaVersion": "1.103.0",
+    "javaGitTag": "v1.103.0",
     "customDependencies": [
     ]
   },
   {
     "providerName": "gcp",
-    "url": "https://gist.githubusercontent.com/myhau/0aa5e4a2a18ea6ae194abd824440e558/raw/6d01f8b7165a0a515eceee9924c0ffc9dd86fbae/schema-gcp-classic-v6.43.0-subset-for-build.json",
-    "kotlinVersion": "6.43.0.0-SNAPSHOT",
-    "javaVersion": "6.43.0",
-    "javaGitTag": "v6.43.0",
+    "url": "https://gist.githubusercontent.com/jplewa/0988583befa715aedcde660feae81002/raw/4cc4ace69b244a3c552071f90e7662e5abb7e91e/schema-gcp-v6.59.0-subset-for-build.json",
+    "kotlinVersion": "6.59.0.0-SNAPSHOT",
+    "javaVersion": "6.59.0",
+    "javaGitTag": "v6.59.0",
     "customDependencies": [
     ]
   },
   {
     "providerName": "google-native",
-    "url": "https://gist.githubusercontent.com/jplewa/73836b04be29884b0b02872843f9136a/raw/ee064931b6cae0bdb3c7ac0adf83e1c019c5fa79/schema-google-native-v0.27.0-subset-for-build.json",
-    "kotlinVersion": "0.27.0.0-SNAPSHOT",
-    "javaVersion": "0.27.0",
-    "javaGitTag": "v0.27.0",
+    "url": "https://gist.githubusercontent.com/jplewa/544b1de415bca905cee9f135c119089e/raw/5b29ca08103a0c00dccfcacb834637853bc56241/schema-google-native-v0.31.0-subset-for-build.json",
+    "kotlinVersion": "0.31.0.0-SNAPSHOT",
+    "javaVersion": "0.31.0",
+    "javaGitTag": "v0.31.0",
     "customDependencies": [
     ]
   },
   {
     "providerName": "kubernetes",
-    "url": "https://gist.githubusercontent.com/jplewa/deddde072fd7b018aac1609772eda28a/raw/7e92997aa7fc2e972cf81662b65b749aaf5b8358/schema-kubernetes-v.3.22.1-subset-for-build.json",
-    "kotlinVersion": "3.22.1.0-SNAPSHOT",
-    "javaVersion": "3.22.1",
-    "javaGitTag": "v3.22.1",
+    "url": "https://gist.githubusercontent.com/jplewa/1d396426206698b29a884b5d85391ee3/raw/cfc2220d07524c9f99e5be14928f91819323ea80/schema-kubernetes-v3.30.1-subset-for-build.json",
+    "kotlinVersion": "3.30.1.0-SNAPSHOT",
+    "javaVersion": "3.30.1",
+    "javaGitTag": "v3.30.1",
     "customDependencies": [
     ]
   }

--- a/src/test/kotlin/org/virtuslab/pulumikotlin/codegen/CodegenTest.kt
+++ b/src/test/kotlin/org/virtuslab/pulumikotlin/codegen/CodegenTest.kt
@@ -24,7 +24,7 @@ class CodegenTest {
     private val logger = KotlinLogging.logger {}
 
     private val dependencies = listOf(
-        "com.pulumi:pulumi:0.6.0",
+        "com.pulumi:pulumi:0.9.4",
         "com.pulumi:aws:5.16.2",
         "com.pulumi:gcp:6.38.0",
         "com.pulumi:slack:0.3.0",
@@ -34,11 +34,11 @@ class CodegenTest {
         "com.pulumi:azure-native:1.85.0",
         "com.pulumi:google-native:0.27.0",
         "com.google.code.findbugs:jsr305:3.0.2",
-        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4",
-        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4",
-        "com.google.code.gson:gson:2.10",
-        "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.4.1",
-        "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.4.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.2",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.2",
+        "com.google.code.gson:gson:2.10.1",
+        "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.5.1",
+        "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.5.1",
     )
 
     private lateinit var testInfo: TestInfo

--- a/src/test/kotlin/org/virtuslab/pulumikotlin/codegen/sdk/opts/CustomResourceOptionsTest.kt
+++ b/src/test/kotlin/org/virtuslab/pulumikotlin/codegen/sdk/opts/CustomResourceOptionsTest.kt
@@ -230,7 +230,6 @@ internal class CustomResourceOptionsTest {
                     "custom timeouts - delete",
                 )
             },
-
         )
     }
 

--- a/src/test/kotlin/org/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScriptTest.kt
+++ b/src/test/kotlin/org/virtuslab/pulumikotlin/scripts/ComputeSchemaSubsetScriptTest.kt
@@ -1,7 +1,6 @@
 package org.virtuslab.pulumikotlin.scripts
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import org.junit.jupiter.api.Assertions.assertAll


### PR DESCRIPTION
## Task

Resolves: None

## Description

In this PR:
- I updated some dependencies,
- I updated the schemas used in E2E tests,
- I updated `ComputeSchemaSubsetScript` so that it can download a schema from a URL instead of having to have a local file,
- I added two configuration properties to the schema version update script (`skipUnstableVersions` and `fastForwardToMostRecentVersion`),
- I removed the timeout from the ktor HTTP client used to query Maven Central,
- I updated the codegen to unwrap `Either<Any, Any>` to `Any` (this is needed to release the newest version of AWS Native).