### PR TITLE
Add logos of Pulumi, Kotlin and VirtusLab to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+<p align="center">
+   <a href="https://virtuslab.com/open-source/"><img width="40" src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/01eaed9a-2acc-455c-a2e7-0c945406447c" /></a>
+</p>
+
 # Pulumi Kotlin SDK
+
+<p align="center">
+    <img src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/feb4d51e-f223-4a80-a164-ed6cb4500526" />
+</p>
 
 Experimental support for Kotlin language in [Pulumi](https://www.pulumi.com/).
 
@@ -773,3 +781,8 @@ Pulumi Kotlin SDK is a proof of concept, **we really need feedback before moving
 [support-for-idiomatic-kotlin-issue]: https://github.com/pulumi/pulumi-java/issues/544
 [pulumi-slack-java-channel]: https://pulumi-community.slack.com/archives/C03DPAY96NB
 [calendly-feedback-meeting]: https://calendly.com/michalfudala/kotlin-sdk-for-pulumi-feedback
+
+
+<p align="center">
+   <a href="https://virtuslab.com/open-source/"><img width="40" src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/01eaed9a-2acc-455c-a2e7-0c945406447c" /></a>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+</br>
 <p align="center">
-   <a href="https://virtuslab.com/open-source/"><img width="40" src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/01eaed9a-2acc-455c-a2e7-0c945406447c" /></a>
+   <img width="40" src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/01eaed9a-2acc-455c-a2e7-0c945406447c" />
 </p>
 
 # Pulumi Kotlin SDK
@@ -786,3 +787,4 @@ Pulumi Kotlin SDK is a proof of concept, **we really need feedback before moving
 <p align="center">
    <a href="https://virtuslab.com/open-source/"><img width="40" src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/01eaed9a-2acc-455c-a2e7-0c945406447c" /></a>
 </p>
+</br>

--- a/README.md
+++ b/README.md
@@ -787,4 +787,3 @@ Pulumi Kotlin SDK is a proof of concept, **we really need feedback before moving
 <p align="center">
    <a href="https://virtuslab.com/open-source/"><img width="40" src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/01eaed9a-2acc-455c-a2e7-0c945406447c" /></a>
 </p>
-</br>


### PR DESCRIPTION
## Task

Resolves: None

## Description

Add some logos to our README.md to make it more visually pleasing.

See [preview](https://github.com/VirtuslabRnD/pulumi-kotlin/tree/add-logos-to-readme).

### Previews

![Screenshot 2023-07-27 at 17 47 41](https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/4fe854cc-c16a-48ca-8e4c-c662a4596b2f)


![Screenshot 2023-07-27 at 17 47 16](https://github.com/VirtuslabRnD/pulumi-kotlin/assets/4415632/ddbe0d49-3618-44da-83e4-ba5e831a92d2)
