### PR TITLE
Release provider libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,14 +358,14 @@ that the Kotlin code has been improved, but the underlying Java library remained
   </tr>
   <tr>
     <td>cloudflare</td>
-    <td>4.16.0.0</td>
+    <td>4.16.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-cloudflare-kotlin</artifactId>
-     <version>4.16.0.0</version>
+     <version>4.16.0.1</version>
 </dependency>
 ```
  
@@ -373,24 +373,24 @@ that the Kotlin code has been improved, but the underlying Java library remained
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-cloudflare-kotlin:4.16.0.0")
+implementation("org.virtuslab:pulumi-cloudflare-kotlin:4.16.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-cloudflare-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/cloudflare">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/cloudflare/4.16.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/cloudflare/4.16.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>cloudflare</td>
-    <td>5.5.0.0</td>
+    <td>5.5.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-cloudflare-kotlin</artifactId>
-     <version>5.5.0.0</version>
+     <version>5.5.0.1</version>
 </dependency>
 ```
  
@@ -398,24 +398,24 @@ implementation("org.virtuslab:pulumi-cloudflare-kotlin:4.16.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-cloudflare-kotlin:5.5.0.0")
+implementation("org.virtuslab:pulumi-cloudflare-kotlin:5.5.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-cloudflare-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/cloudflare">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/cloudflare/5.5.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/cloudflare/5.5.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>slack</td>
-    <td>0.4.2.0</td>
+    <td>0.4.2.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-slack-kotlin</artifactId>
-     <version>0.4.2.0</version>
+     <version>0.4.2.1</version>
 </dependency>
 ```
  
@@ -423,24 +423,24 @@ implementation("org.virtuslab:pulumi-cloudflare-kotlin:5.5.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-slack-kotlin:0.4.2.0")
+implementation("org.virtuslab:pulumi-slack-kotlin:0.4.2.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-slack-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/slack">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/slack/0.4.2.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/slack/0.4.2.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>github</td>
-    <td>5.16.0.0</td>
+    <td>5.16.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-github-kotlin</artifactId>
-     <version>5.16.0.0</version>
+     <version>5.16.0.1</version>
 </dependency>
 ```
  
@@ -448,24 +448,24 @@ implementation("org.virtuslab:pulumi-slack-kotlin:0.4.2.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-github-kotlin:5.16.0.0")
+implementation("org.virtuslab:pulumi-github-kotlin:5.16.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-github-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/github">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/github/5.16.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/github/5.16.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>random</td>
-    <td>4.13.2.0</td>
+    <td>4.13.2.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-random-kotlin</artifactId>
-     <version>4.13.2.0</version>
+     <version>4.13.2.1</version>
 </dependency>
 ```
  
@@ -473,24 +473,24 @@ implementation("org.virtuslab:pulumi-github-kotlin:5.16.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-random-kotlin:4.13.2.0")
+implementation("org.virtuslab:pulumi-random-kotlin:4.13.2.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-random-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/random">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/random/4.13.2.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/random/4.13.2.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>gcp</td>
-    <td>6.64.0.0</td>
+    <td>6.64.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-gcp-kotlin</artifactId>
-     <version>6.64.0.0</version>
+     <version>6.64.0.1</version>
 </dependency>
 ```
  
@@ -498,24 +498,24 @@ implementation("org.virtuslab:pulumi-random-kotlin:4.13.2.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-gcp-kotlin:6.64.0.0")
+implementation("org.virtuslab:pulumi-gcp-kotlin:6.64.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-gcp-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/gcp">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/gcp/6.64.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/gcp/6.64.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>google-native</td>
-    <td>0.31.1.0</td>
+    <td>0.31.1.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-google-native-kotlin</artifactId>
-     <version>0.31.1.0</version>
+     <version>0.31.1.1</version>
 </dependency>
 ```
  
@@ -523,24 +523,24 @@ implementation("org.virtuslab:pulumi-gcp-kotlin:6.64.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-google-native-kotlin:0.31.1.0")
+implementation("org.virtuslab:pulumi-google-native-kotlin:0.31.1.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-google-native-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/google-native">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/google-native/0.31.1.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/google-native/0.31.1.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>aws</td>
-    <td>5.42.0.0</td>
+    <td>5.42.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-aws-kotlin</artifactId>
-     <version>5.42.0.0</version>
+     <version>5.42.0.1</version>
 </dependency>
 ```
  
@@ -548,24 +548,24 @@ implementation("org.virtuslab:pulumi-google-native-kotlin:0.31.1.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-aws-kotlin:5.42.0.0")
+implementation("org.virtuslab:pulumi-aws-kotlin:5.42.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-aws-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/aws">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/aws/5.42.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/aws/5.42.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>aws-native</td>
-    <td>0.73.1.0</td>
+    <td>0.73.1.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-aws-native-kotlin</artifactId>
-     <version>0.73.1.0</version>
+     <version>0.73.1.1</version>
 </dependency>
 ```
  
@@ -573,24 +573,24 @@ implementation("org.virtuslab:pulumi-aws-kotlin:5.42.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-aws-native-kotlin:0.73.1.0")
+implementation("org.virtuslab:pulumi-aws-native-kotlin:0.73.1.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-aws-native-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/aws-native">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/aws-native/0.73.1.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/aws-native/0.73.1.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>azure</td>
-    <td>5.48.1.0</td>
+    <td>5.48.1.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-azure-kotlin</artifactId>
-     <version>5.48.1.0</version>
+     <version>5.48.1.1</version>
 </dependency>
 ```
  
@@ -598,24 +598,24 @@ implementation("org.virtuslab:pulumi-aws-native-kotlin:0.73.1.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-azure-kotlin:5.48.1.0")
+implementation("org.virtuslab:pulumi-azure-kotlin:5.48.1.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-azure-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/azure">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/azure/5.48.1.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/azure/5.48.1.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>azure-native</td>
-    <td>1.104.0.0</td>
+    <td>1.104.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-azure-native-kotlin</artifactId>
-     <version>1.104.0.0</version>
+     <version>1.104.0.1</version>
 </dependency>
 ```
  
@@ -623,24 +623,24 @@ implementation("org.virtuslab:pulumi-azure-kotlin:5.48.1.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-azure-native-kotlin:1.104.0.0")
+implementation("org.virtuslab:pulumi-azure-native-kotlin:1.104.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-azure-native-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/azure-native">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/azure-native/1.104.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/azure-native/1.104.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>azure-native</td>
-    <td>2.4.0.0</td>
+    <td>2.4.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-azure-native-kotlin</artifactId>
-     <version>2.4.0.0</version>
+     <version>2.4.0.1</version>
 </dependency>
 ```
  
@@ -648,24 +648,24 @@ implementation("org.virtuslab:pulumi-azure-native-kotlin:1.104.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-azure-native-kotlin:2.4.0.0")
+implementation("org.virtuslab:pulumi-azure-native-kotlin:2.4.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-azure-native-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/azure-native">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/azure-native/2.4.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/azure-native/2.4.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>kubernetes</td>
-    <td>3.30.2.0</td>
+    <td>3.30.2.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-kubernetes-kotlin</artifactId>
-     <version>3.30.2.0</version>
+     <version>3.30.2.1</version>
 </dependency>
 ```
  
@@ -673,24 +673,24 @@ implementation("org.virtuslab:pulumi-azure-native-kotlin:2.4.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-kubernetes-kotlin:3.30.2.0")
+implementation("org.virtuslab:pulumi-kubernetes-kotlin:3.30.2.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-kubernetes-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/kubernetes">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/kubernetes/3.30.2.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/kubernetes/3.30.2.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>kubernetes</td>
-    <td>4.1.1.0</td>
+    <td>4.1.1.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-kubernetes-kotlin</artifactId>
-     <version>4.1.1.0</version>
+     <version>4.1.1.1</version>
 </dependency>
 ```
  
@@ -698,24 +698,24 @@ implementation("org.virtuslab:pulumi-kubernetes-kotlin:3.30.2.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-kubernetes-kotlin:4.1.1.0")
+implementation("org.virtuslab:pulumi-kubernetes-kotlin:4.1.1.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-kubernetes-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/kubernetes">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/kubernetes/4.1.1.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/kubernetes/4.1.1.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>nomad</td>
-    <td>0.4.1.0</td>
+    <td>0.4.1.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-nomad-kotlin</artifactId>
-     <version>0.4.1.0</version>
+     <version>0.4.1.1</version>
 </dependency>
 ```
  
@@ -723,24 +723,24 @@ implementation("org.virtuslab:pulumi-kubernetes-kotlin:4.1.1.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-nomad-kotlin:0.4.1.0")
+implementation("org.virtuslab:pulumi-nomad-kotlin:0.4.1.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-nomad-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/nomad">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/nomad/0.4.1.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/nomad/0.4.1.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>docker</td>
-    <td>3.6.1.1</td>
+    <td>3.6.1.2</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-docker-kotlin</artifactId>
-     <version>3.6.1.1</version>
+     <version>3.6.1.2</version>
 </dependency>
 ```
  
@@ -748,24 +748,24 @@ implementation("org.virtuslab:pulumi-nomad-kotlin:0.4.1.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-docker-kotlin:3.6.1.1")
+implementation("org.virtuslab:pulumi-docker-kotlin:3.6.1.2")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-docker-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/docker">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/docker/3.6.1.1/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/docker/3.6.1.2/index.html">link</a></td>
   </tr>
   <tr>
     <td>docker</td>
-    <td>4.3.0.0</td>
+    <td>4.3.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-docker-kotlin</artifactId>
-     <version>4.3.0.0</version>
+     <version>4.3.0.1</version>
 </dependency>
 ```
  
@@ -773,24 +773,24 @@ implementation("org.virtuslab:pulumi-docker-kotlin:3.6.1.1")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-docker-kotlin:4.3.0.0")
+implementation("org.virtuslab:pulumi-docker-kotlin:4.3.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-docker-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/docker">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/docker/4.3.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/docker/4.3.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>gitlab</td>
-    <td>4.10.0.0</td>
+    <td>4.10.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-gitlab-kotlin</artifactId>
-     <version>4.10.0.0</version>
+     <version>4.10.0.1</version>
 </dependency>
 ```
  
@@ -798,24 +798,24 @@ implementation("org.virtuslab:pulumi-docker-kotlin:4.3.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-gitlab-kotlin:4.10.0.0")
+implementation("org.virtuslab:pulumi-gitlab-kotlin:4.10.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-gitlab-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/gitlab">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/gitlab/4.10.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/gitlab/4.10.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>gitlab</td>
-    <td>5.0.2.0</td>
+    <td>5.0.2.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-gitlab-kotlin</artifactId>
-     <version>5.0.2.0</version>
+     <version>5.0.2.1</version>
 </dependency>
 ```
  
@@ -823,24 +823,24 @@ implementation("org.virtuslab:pulumi-gitlab-kotlin:4.10.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-gitlab-kotlin:5.0.2.0")
+implementation("org.virtuslab:pulumi-gitlab-kotlin:5.0.2.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-gitlab-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/gitlab">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/gitlab/5.0.2.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/gitlab/5.0.2.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>gitlab</td>
-    <td>6.1.0.0</td>
+    <td>6.1.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-gitlab-kotlin</artifactId>
-     <version>6.1.0.0</version>
+     <version>6.1.0.1</version>
 </dependency>
 ```
  
@@ -848,24 +848,24 @@ implementation("org.virtuslab:pulumi-gitlab-kotlin:5.0.2.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-gitlab-kotlin:6.1.0.0")
+implementation("org.virtuslab:pulumi-gitlab-kotlin:6.1.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-gitlab-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/gitlab">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/gitlab/6.1.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/gitlab/6.1.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>digitalocean</td>
-    <td>4.21.0.0</td>
+    <td>4.21.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-digitalocean-kotlin</artifactId>
-     <version>4.21.0.0</version>
+     <version>4.21.0.1</version>
 </dependency>
 ```
  
@@ -873,24 +873,24 @@ implementation("org.virtuslab:pulumi-gitlab-kotlin:6.1.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-digitalocean-kotlin:4.21.0.0")
+implementation("org.virtuslab:pulumi-digitalocean-kotlin:4.21.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-digitalocean-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/digitalocean">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/digitalocean/4.21.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/digitalocean/4.21.0.1/index.html">link</a></td>
   </tr>
   <tr>
     <td>alicloud</td>
-    <td>3.43.0.0</td>
+    <td>3.43.0.1</td>
     <td> 
  
 ```xml
 <dependency>
      <groupId>org.virtuslab</groupId>
      <artifactId>pulumi-alicloud-kotlin</artifactId>
-     <version>3.43.0.0</version>
+     <version>3.43.0.1</version>
 </dependency>
 ```
  
@@ -898,13 +898,13 @@ implementation("org.virtuslab:pulumi-digitalocean-kotlin:4.21.0.0")
     <td> 
  
 ```kt
-implementation("org.virtuslab:pulumi-alicloud-kotlin:3.43.0.0")
+implementation("org.virtuslab:pulumi-alicloud-kotlin:3.43.0.1")
 ```
  
  </td>
     <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-alicloud-kotlin">link</a></td>
     <td><a href="https://www.pulumi.com/registry/packages/alicloud">link</a></td>
-    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/alicloud/3.43.0.0/index.html">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/alicloud/3.43.0.1/index.html">link</a></td>
   </tr>
 </table>
 

--- a/src/main/resources/version-config.json
+++ b/src/main/resources/version-config.json
@@ -2,7 +2,7 @@
   {
     "providerName": "cloudflare",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-cloudflare/v4.16.0/provider/cmd/pulumi-resource-cloudflare/schema.json",
-    "kotlinVersion": "4.16.0.1-SNAPSHOT",
+    "kotlinVersion": "4.16.0.1",
     "javaVersion": "4.16.0",
     "javaGitTag": "v4.16.0",
     "customDependencies": [
@@ -11,7 +11,7 @@
   {
     "providerName": "cloudflare",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-cloudflare/v5.5.0/provider/cmd/pulumi-resource-cloudflare/schema.json",
-    "kotlinVersion": "5.5.0.1-SNAPSHOT",
+    "kotlinVersion": "5.5.0.1",
     "javaVersion": "5.5.0",
     "javaGitTag": "v5.5.0",
     "customDependencies": [
@@ -20,7 +20,7 @@
   {
     "providerName": "slack",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-slack/v0.4.2/provider/cmd/pulumi-resource-slack/schema.json",
-    "kotlinVersion": "0.4.2.1-SNAPSHOT",
+    "kotlinVersion": "0.4.2.1",
     "javaVersion": "0.4.2",
     "javaGitTag": "v0.4.2",
     "customDependencies": [
@@ -29,7 +29,7 @@
   {
     "providerName": "github",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-github/v5.16.0/provider/cmd/pulumi-resource-github/schema.json",
-    "kotlinVersion": "5.16.0.1-SNAPSHOT",
+    "kotlinVersion": "5.16.0.1",
     "javaVersion": "5.16.0",
     "javaGitTag": "v5.16.0",
     "customDependencies": [
@@ -38,7 +38,7 @@
   {
     "providerName": "random",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-random/v4.13.2/provider/cmd/pulumi-resource-random/schema.json",
-    "kotlinVersion": "4.13.2.1-SNAPSHOT",
+    "kotlinVersion": "4.13.2.1",
     "javaVersion": "4.13.2",
     "javaGitTag": "v4.13.2",
     "customDependencies": [
@@ -47,7 +47,7 @@
   {
     "providerName": "gcp",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-gcp/v6.64.0/provider/cmd/pulumi-resource-gcp/schema.json",
-    "kotlinVersion": "6.64.0.1-SNAPSHOT",
+    "kotlinVersion": "6.64.0.1",
     "javaVersion": "6.64.0",
     "javaGitTag": "v6.64.0",
     "customDependencies": [
@@ -56,7 +56,7 @@
   {
     "providerName": "google-native",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-google-native/v0.31.1/provider/cmd/pulumi-resource-google-native/schema.json",
-    "kotlinVersion": "0.31.1.1-SNAPSHOT",
+    "kotlinVersion": "0.31.1.1",
     "javaVersion": "0.31.1",
     "javaGitTag": "v0.31.1",
     "customDependencies": [
@@ -65,7 +65,7 @@
   {
     "providerName": "aws",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-aws/v5.42.0/provider/cmd/pulumi-resource-aws/schema.json",
-    "kotlinVersion": "5.42.0.1-SNAPSHOT",
+    "kotlinVersion": "5.42.0.1",
     "javaVersion": "5.42.0",
     "javaGitTag": "v5.42.0",
     "customDependencies": [
@@ -74,7 +74,7 @@
   {
     "providerName": "aws-native",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-aws-native/v0.73.1/provider/cmd/pulumi-resource-aws-native/schema.json",
-    "kotlinVersion": "0.73.1.1-SNAPSHOT",
+    "kotlinVersion": "0.73.1.1",
     "javaVersion": "0.73.1",
     "javaGitTag": "v0.73.1",
     "customDependencies": [
@@ -83,7 +83,7 @@
   {
     "providerName": "azure",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-azure/v5.48.1/provider/cmd/pulumi-resource-azure/schema.json",
-    "kotlinVersion": "5.48.1.1-SNAPSHOT",
+    "kotlinVersion": "5.48.1.1",
     "javaVersion": "5.48.1",
     "javaGitTag": "v5.48.1",
     "customDependencies": [
@@ -92,7 +92,7 @@
   {
     "providerName": "azure-native",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-azure-native/v1.104.0/provider/cmd/pulumi-resource-azure-native/schema.json",
-    "kotlinVersion": "1.104.0.1-SNAPSHOT",
+    "kotlinVersion": "1.104.0.1",
     "javaVersion": "1.104.0",
     "javaGitTag": "v1.104.0",
     "customDependencies": [
@@ -101,7 +101,7 @@
   {
     "providerName": "azure-native",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-azure-native/v2.4.0/provider/cmd/pulumi-resource-azure-native/schema.json",
-    "kotlinVersion": "2.4.0.1-SNAPSHOT",
+    "kotlinVersion": "2.4.0.1",
     "javaVersion": "2.4.0",
     "javaGitTag": "v2.4.0",
     "customDependencies": [
@@ -110,7 +110,7 @@
   {
     "providerName": "kubernetes",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/v3.30.2/provider/cmd/pulumi-resource-kubernetes/schema.json",
-    "kotlinVersion": "3.30.2.1-SNAPSHOT",
+    "kotlinVersion": "3.30.2.1",
     "javaVersion": "3.30.2",
     "javaGitTag": "v3.30.2",
     "customDependencies": [
@@ -119,7 +119,7 @@
   {
     "providerName": "kubernetes",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/v4.1.1/provider/cmd/pulumi-resource-kubernetes/schema.json",
-    "kotlinVersion": "4.1.1.1-SNAPSHOT",
+    "kotlinVersion": "4.1.1.1",
     "javaVersion": "4.1.1",
     "javaGitTag": "v4.1.1",
     "customDependencies": [
@@ -128,7 +128,7 @@
   {
     "providerName": "nomad",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-nomad/v0.4.1/provider/cmd/pulumi-resource-nomad/schema.json",
-    "kotlinVersion": "0.4.1.1-SNAPSHOT",
+    "kotlinVersion": "0.4.1.1",
     "javaVersion": "0.4.1",
     "javaGitTag": "v0.4.1",
     "customDependencies": [
@@ -137,7 +137,7 @@
   {
     "providerName": "docker",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-docker/v3.6.1/provider/cmd/pulumi-resource-docker/schema.json",
-    "kotlinVersion": "3.6.1.2-SNAPSHOT",
+    "kotlinVersion": "3.6.1.2",
     "javaVersion": "3.6.1",
     "javaGitTag": "v3.6.1",
     "customDependencies": [
@@ -146,7 +146,7 @@
   {
     "providerName": "docker",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-docker/v4.3.0/provider/cmd/pulumi-resource-docker/schema.json",
-    "kotlinVersion": "4.3.0.1-SNAPSHOT",
+    "kotlinVersion": "4.3.0.1",
     "javaVersion": "4.3.0",
     "javaGitTag": "v4.3.0",
     "customDependencies": [
@@ -155,7 +155,7 @@
   {
     "providerName": "gitlab",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-gitlab/v4.10.0/provider/cmd/pulumi-resource-gitlab/schema.json",
-    "kotlinVersion": "4.10.0.1-SNAPSHOT",
+    "kotlinVersion": "4.10.0.1",
     "javaVersion": "4.10.0",
     "javaGitTag": "v4.10.0",
     "customDependencies": [
@@ -164,7 +164,7 @@
   {
     "providerName": "gitlab",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-gitlab/v5.0.2/provider/cmd/pulumi-resource-gitlab/schema.json",
-    "kotlinVersion": "5.0.2.1-SNAPSHOT",
+    "kotlinVersion": "5.0.2.1",
     "javaVersion": "5.0.2",
     "javaGitTag": "v5.0.2",
     "customDependencies": [
@@ -173,7 +173,7 @@
   {
     "providerName": "gitlab",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-gitlab/v6.1.0/provider/cmd/pulumi-resource-gitlab/schema.json",
-    "kotlinVersion": "6.1.0.1-SNAPSHOT",
+    "kotlinVersion": "6.1.0.1",
     "javaVersion": "6.1.0",
     "javaGitTag": "v6.1.0",
     "customDependencies": [
@@ -182,7 +182,7 @@
   {
     "providerName": "digitalocean",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-digitalocean/v4.21.0/provider/cmd/pulumi-resource-digitalocean/schema.json",
-    "kotlinVersion": "4.21.0.1-SNAPSHOT",
+    "kotlinVersion": "4.21.0.1",
     "javaVersion": "4.21.0",
     "javaGitTag": "v4.21.0",
     "customDependencies": [
@@ -191,7 +191,7 @@
   {
     "providerName": "alicloud",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-alicloud/v3.43.0/provider/cmd/pulumi-resource-alicloud/schema.json",
-    "kotlinVersion": "3.43.0.1-SNAPSHOT",
+    "kotlinVersion": "3.43.0.1",
     "javaVersion": "3.43.0",
     "javaGitTag": "v3.43.0",
     "customDependencies": [


### PR DESCRIPTION
## Task

Resolves: None

## Description

This release includes the following versions:
cloudflare/v4.16.0.1
cloudflare/v5.5.0.1
slack/v0.4.2.1
github/v5.16.0.1
random/v4.13.2.1
gcp/v6.64.0.1
google-native/v0.31.1.1
aws/v5.42.0.1
aws-native/v0.73.1.1
azure/v5.48.1.1
azure-native/v1.104.0.1
azure-native/v2.4.0.1
kubernetes/v3.30.2.1
kubernetes/v4.1.1.1
nomad/v0.4.1.1
docker/v3.6.1.2
docker/v4.3.0.1
gitlab/v4.10.0.1
gitlab/v5.0.2.1
gitlab/v6.1.0.1
digitalocean/v4.21.0.1
alicloud/v3.43.0.1

The reason for this release is for all the libraries to rely on the common `pulumi-kotlin` SDK from now on.
