### PR TITLE
Add new AWS major

### DIFF
--- a/src/main/resources/version-config.json
+++ b/src/main/resources/version-config.json
@@ -72,6 +72,15 @@
     ]
   },
   {
+    "providerName": "aws",
+    "url": "https://raw.githubusercontent.com/pulumi/pulumi-aws/v6.0.2/provider/cmd/pulumi-resource-aws/schema.json",
+    "kotlinVersion": "6.0.2.0-SNAPSHOT",
+    "javaVersion": "6.0.2",
+    "javaGitTag": "v6.0.2",
+    "customDependencies": [
+    ]
+  },
+  {
     "providerName": "aws-native",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-aws-native/v0.75.0/provider/cmd/pulumi-resource-aws-native/schema.json",
     "kotlinVersion": "0.75.0.1-SNAPSHOT",


### PR DESCRIPTION
## Task

Resolves: None

## Description

A new major version appeared for AWS. **Note**: there's also version `6.0.0` available on Maven Central, but there's no schema tagged for that one, so we have to skip it.
