### PR TITLE
Add missing aws6 provider to GH Actions

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -56,6 +56,8 @@ jobs:
             majorVersion: 0
           - provider: aws
             majorVersion: 5
+          - provider: aws
+            majorVersion: 6
           - provider: aws-native
             majorVersion: 0
           - provider: azure

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -54,6 +54,8 @@ jobs:
             majorVersion: 0
           - provider: aws
             majorVersion: 5
+          - provider: aws
+            majorVersion: 6
           - provider: aws-native
             majorVersion: 0
           - provider: azure


### PR DESCRIPTION
## Task

Resolves: None

## Description

I forgot to add that in https://github.com/VirtuslabRnD/pulumi-kotlin/pull/320. I made two AWS6 releases manually, because they got skipped by the CI.
