### PR TITLE
Persist buildSrc test reports in case of failure

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -117,6 +117,7 @@ jobs:
           distribution: adopt
           java-version: 11
       - name: Publish packages
+        id: publish-to-maven-central
         if: ${{ steps.check-for-release.outputs.is_release == 'true' }}
         run: |
           ./gradlew publishPulumi${{ matrix.provider }}${{ matrix.majorVersion }}PublicationToMavenCentralRepository \
@@ -152,6 +153,13 @@ jobs:
         if: ${{ steps.check-for-release.outputs.is_release == 'true' }}
         run: |
           rclone copy --transfers=1024 ./docs/${{ matrix.provider }} rclone-jvm-lab:/pulumi-kotlin-docs/${{ matrix.provider }}
+      - name: Upload buildSrc test report
+        if: ${{ failure() && steps.publish-to-maven-central.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-src-test-report
+          path: ./buildSrc/build/reports/tests/test/*
+          retention-days: 3          
   cleanup:
     name: Clean up after release
     needs: tag

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -110,8 +110,16 @@ jobs:
             with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
               fh.write('is_release=' + str(is_release).lower())
       - name: Publish to Maven Local
+        id: publish-to-maven-local
         run: ./gradlew publishPulumi${{ matrix.provider }}${{ matrix.majorVersion }}PublicationToMavenLocal -Dorg.gradle.daemon=false -q
         if: |
           (startsWith(github.head_ref, 'prepare-release') && steps.check-for-release.outputs.is_release == 'true') || 
           (github.event_name == 'push' && steps.check-for-release.outputs.is_release == 'false') || 
           github.event_name == 'workflow_dispatch'
+      - name: Upload buildSrc test report
+        if: ${{ failure() && steps.publish-to-maven-local.outcome == 'failure' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-src-test-report
+          path: ./buildSrc/build/reports/tests/test/*
+          retention-days: 3


### PR DESCRIPTION
## Task

Resolves: None

## Description

Publication to Maven Local has been flaky for the past few days and I want to verify if it's due to networking issues on GitHub Actions or something else.