### PR TITLE
Add support for cockroach Kotlin generation.

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -86,6 +86,8 @@ jobs:
             majorVersion: 4
           - provider: alicloud
             majorVersion: 3
+          - provider: cockroach
+            majorVersion: 0
     steps:
       - id: provider
         uses: ASzc/change-string-case-action@v5

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -84,6 +84,8 @@ jobs:
             majorVersion: 4
           - provider: alicloud
             majorVersion: 3
+          - provider: cockroach
+            majorVersion: 0
     steps:
       - name: Check out project sources
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -961,6 +961,31 @@ implementation("org.virtuslab:pulumi-alicloud-kotlin:3.44.1.0")
     <td><a href="https://www.pulumi.com/registry/packages/alicloud">link</a></td>
     <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/alicloud/3.44.1.0/index.html">link</a></td>
   </tr>
+  <tr>
+    <td>coackroach</td>
+    <td>0.1.0</td>
+    <td> 
+ 
+```xml
+<dependency>
+     <groupId>org.virtuslab</groupId>
+     <artifactId>pulumi-cockroach-kotlin</artifactId>
+     <version>0.1.0</version>
+</dependency>
+```
+ 
+ </td>
+    <td> 
+ 
+```kt
+implementation("org.virtuslab:pulumi-cockroach-kotlin:0.1.0.0")
+```
+ 
+ </td>
+    <td><a href="https://search.maven.org/artifact/org.virtuslab/pulumi-cockroach-kotlin">link</a></td>
+    <td><a href="https://www.pulumi.com/registry/packages/cockroach">link</a></td>
+    <td><a href="https://storage.googleapis.com/pulumi-kotlin-docs/cockroach/0.1.0.0/index.html">link</a></td>
+  </tr>
 </table>
 
 ## Giving feedback

--- a/src/main/resources/version-config.json
+++ b/src/main/resources/version-config.json
@@ -205,5 +205,14 @@
     "javaGitTag": "v3.44.1",
     "customDependencies": [
     ]
+  },
+  {
+    "providerName": "cockroach",
+    "url": "https://raw.githubusercontent.com/lbrlabs/pulumi-cockroach/v0.1.0/provider/cmd/pulumi-resource-cockroach/schema.json",
+    "kotlinVersion": "0.1.0.0-SNAPSHOT",
+    "javaVersion": "0.1.0",
+    "javaGitTag": "v0.1.0",
+    "customDependencies": [
+    ]
   }
 ]


### PR DESCRIPTION
## Task

Resolves: #389

## Description

Add supports for coackroach DB Kotlin generation.

This was done by look at an example like digitalocean: https://github.com/search?q=repo%3AVirtuslabRnD%2Fpulumi-kotlin%20digitalocean&type=code

Note that the JSON source owner is not pulumi in this case, but lbrlabs, as pointed to by https://www.pulumi.com/registry/packages/cockroach/.
