### PR TITLE
Add destructing extension functions for tuples

### DIFF
--- a/sdk/src/main/kotlin/com/pulumi/kotlin/Tuples.kt
+++ b/sdk/src/main/kotlin/com/pulumi/kotlin/Tuples.kt
@@ -1,0 +1,291 @@
+package com.pulumi.kotlin
+
+import com.pulumi.core.Tuples
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple1] to work with destructuring declarations.
+ *
+ * @param T the type of the first component.
+ * @return The first component.
+ */
+operator fun <T> Tuples.Tuple1<T>.component1(): T? = t1
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple2] to work with destructuring declarations.
+ *
+ * @param T the type of the first component.
+ * @return The first component.
+ */
+operator fun <T> Tuples.Tuple2<T, *>.component1(): T? = t1
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple2] to work with destructuring declarations.
+ *
+ * @param T the type of the second component.
+ * @return The second component.
+ */
+operator fun <T> Tuples.Tuple2<*, T>.component2(): T? = t2
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple3] to work with destructuring declarations.
+ *
+ * @param T the type of the first component.
+ * @return The first component.
+ */
+operator fun <T> Tuples.Tuple3<T, *, *>.component1(): T? = t1
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple3] to work with destructuring declarations.
+ *
+ * @param T the type of the second component.
+ * @return The second component.
+ */
+operator fun <T> Tuples.Tuple3<*, T, *>.component2(): T? = t2
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple3] to work with destructuring declarations.
+ *
+ * @param T the type of the third component.
+ * @return The third component.
+ */
+operator fun <T> Tuples.Tuple3<*, *, T>.component3(): T? = t3
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple4] to work with destructuring declarations.
+ *
+ * @param T the type of the first component.
+ * @return The first component.
+ */
+operator fun <T> Tuples.Tuple4<T, *, *, *>.component1(): T? = t1
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple4] to work with destructuring declarations.
+ *
+ * @param T the type of the second component.
+ * @return The second component.
+ */
+operator fun <T> Tuples.Tuple4<*, T, *, *>.component2(): T? = t2
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple4] to work with destructuring declarations.
+ *
+ * @param T the type of the third component.
+ * @return The third component.
+ */
+operator fun <T> Tuples.Tuple4<*, *, T, *>.component3(): T? = t3
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple4] to work with destructuring declarations.
+ *
+ * @param T the type of the fourth component.
+ * @return The fourth component.
+ */
+operator fun <T> Tuples.Tuple4<*, *, *, T>.component4(): T? = t4
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple5] to work with destructuring declarations.
+ *
+ * @param T the type of the first component.
+ * @return The first component.
+ */
+operator fun <T> Tuples.Tuple5<T, *, *, *, *>.component1(): T? = t1
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple5] to work with destructuring declarations.
+ *
+ * @param T the type of the second component.
+ * @return The second component.
+ */
+operator fun <T> Tuples.Tuple5<*, T, *, *, *>.component2(): T? = t2
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple5] to work with destructuring declarations.
+ *
+ * @param T the type of the third component.
+ * @return The third component.
+ */
+operator fun <T> Tuples.Tuple5<*, *, T, *, *>.component3(): T? = t3
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple5] to work with destructuring declarations.
+ *
+ * @param T the type of the fourth component.
+ * @return The fourth component.
+ */
+operator fun <T> Tuples.Tuple5<*, *, *, T, *>.component4(): T? = t4
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple5] to work with destructuring declarations.
+ *
+ * @param T the type of the fifth component.
+ * @return The fifth component.
+ */
+operator fun <T> Tuples.Tuple5<*, *, *, *, T>.component5(): T? = t5
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple6] to work with destructuring declarations.
+ *
+ * @param T the type of the first component.
+ * @return The first component.
+ */
+operator fun <T> Tuples.Tuple6<T, *, *, *, *, *>.component1(): T? = t1
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple6] to work with destructuring declarations.
+ *
+ * @param T the type of the second component.
+ * @return The second component.
+ */
+operator fun <T> Tuples.Tuple6<*, T, *, *, *, *>.component2(): T? = t2
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple6] to work with destructuring declarations.
+ *
+ * @param T the type of the third component.
+ * @return The third component.
+ */
+operator fun <T> Tuples.Tuple6<*, *, T, *, *, *>.component3(): T? = t3
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple6] to work with destructuring declarations.
+ *
+ * @param T the type of the fourth component.
+ * @return The fourth component.
+ */
+operator fun <T> Tuples.Tuple6<*, *, *, T, *, *>.component4(): T? = t4
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple6] to work with destructuring declarations.
+ *
+ * @param T the type of the fifth component.
+ * @return The fifth component.
+ */
+operator fun <T> Tuples.Tuple6<*, *, *, *, T, *>.component5(): T? = t5
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple6] to work with destructuring declarations.
+ *
+ * @param T the type of the sixth component.
+ * @return The sixth component.
+ */
+operator fun <T> Tuples.Tuple6<*, *, *, *, *, T>.component6(): T? = t6
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple7] to work with destructuring declarations.
+ *
+ * @param T the type of the first component.
+ * @return The first component.
+ */
+operator fun <T> Tuples.Tuple7<T, *, *, *, *, *, *>.component1(): T? = t1
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple7] to work with destructuring declarations.
+ *
+ * @param T the type of the second component.
+ * @return The second component.
+ */
+operator fun <T> Tuples.Tuple7<*, T, *, *, *, *, *>.component2(): T? = t2
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple7] to work with destructuring declarations.
+ *
+ * @param T the type of the third component.
+ * @return The third component.
+ */
+operator fun <T> Tuples.Tuple7<*, *, T, *, *, *, *>.component3(): T? = t3
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple7] to work with destructuring declarations.
+ *
+ * @param T the type of the fourth component.
+ * @return The fourth component.
+ */
+operator fun <T> Tuples.Tuple7<*, *, *, T, *, *, *>.component4(): T? = t4
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple7] to work with destructuring declarations.
+ *
+ * @param T the type of the fifth component.
+ * @return The fifth component.
+ */
+operator fun <T> Tuples.Tuple7<*, *, *, *, T, *, *>.component5(): T? = t5
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple7] to work with destructuring declarations.
+ *
+ * @param T the type of the sixth component.
+ * @return The sixth component.
+ */
+operator fun <T> Tuples.Tuple7<*, *, *, *, *, T, *>.component6(): T? = t6
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple7] to work with destructuring declarations.
+ *
+ * @param T the type of the seventh component.
+ * @return The seventh component.
+ */
+operator fun <T> Tuples.Tuple7<*, *, *, *, *, *, T>.component7(): T? = t7
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple8] to work with destructuring declarations.
+ *
+ * @param T the type of the first component.
+ * @return The first component.
+ */
+operator fun <T> Tuples.Tuple8<T, *, *, *, *, *, *, *>.component1(): T? = t1
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple8] to work with destructuring declarations.
+ *
+ * @param T the type of the second component.
+ * @return The second component.
+ */
+operator fun <T> Tuples.Tuple8<*, T, *, *, *, *, *, *>.component2(): T? = t2
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple8] to work with destructuring declarations.
+ *
+ * @param T the type of the third component.
+ * @return The third component.
+ */
+operator fun <T> Tuples.Tuple8<*, *, T, *, *, *, *, *>.component3(): T? = t3
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple8] to work with destructuring declarations.
+ *
+ * @param T the type of the fourth component.
+ * @return The fourth component.
+ */
+operator fun <T> Tuples.Tuple8<*, *, *, T, *, *, *, *>.component4(): T? = t4
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple8] to work with destructuring declarations.
+ *
+ * @param T the type of the fifth component.
+ * @return The fifth component.
+ */
+operator fun <T> Tuples.Tuple8<*, *, *, *, T, *, *, *>.component5(): T? = t5
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple8] to work with destructuring declarations.
+ *
+ * @param T the type of the sixth component.
+ * @return The sixth component.
+ */
+operator fun <T> Tuples.Tuple8<*, *, *, *, *, T, *, *>.component6(): T? = t6
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple8] to work with destructuring declarations.
+ *
+ * @param T the type of the seventh component.
+ * @return The seventh component.
+ */
+operator fun <T> Tuples.Tuple8<*, *, *, *, *, *, T, *>.component7(): T? = t7
+
+/**
+ * Extension for [com.pulumi.core.Tuples.Tuple8] to work with destructuring declarations.
+ *
+ * @param T the type of the eighth component.
+ * @return The eighth component.
+ */
+operator fun <T> Tuples.Tuple8<*, *, *, *, *, *, *, T>.component8(): T? = t8

--- a/sdk/src/test/kotlin/com/pulumi/kotlin/TuplesTest.kt
+++ b/sdk/src/test/kotlin/com/pulumi/kotlin/TuplesTest.kt
@@ -1,6 +1,8 @@
 package com.pulumi.kotlin
 
 import com.pulumi.core.Tuples
+import java.math.BigDecimal
+import java.math.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -8,85 +10,85 @@ class TuplesTest {
 
     @Test
     fun `can destruct Tuple1`() {
-        val tuple = Tuples.Tuple1("one")
+        val tuple = Tuples.Tuple1(1.toByte())
         val (value1) = tuple
-        assertEquals("one", value1)
+        assertEquals(1.toByte(), value1)
     }
 
     @Test
     fun `can destruct Tuple2`() {
-        val tuple = Tuples.Tuple2("one", "two")
+        val tuple = Tuples.Tuple2(1.toByte(), 2)
         val (value1, value2) = tuple
-        assertEquals("one", value1)
-        assertEquals("two", value2)
+        assertEquals(1.toByte(), value1)
+        assertEquals(2, value2)
     }
 
     @Test
     fun `can destruct Tuple3`() {
-        val tuple = Tuples.Tuple3("one", "two", "three")
+        val tuple = Tuples.Tuple3(1.toByte(), 2, 3L)
         val (value1, value2, value3) = tuple
-        assertEquals("one", value1)
-        assertEquals("two", value2)
-        assertEquals("three", value3)
+        assertEquals(1.toByte(), value1)
+        assertEquals(2, value2)
+        assertEquals(3L, value3)
     }
 
     @Test
     fun `can destruct Tuple4`() {
-        val tuple = Tuples.Tuple4("one", "two", "three", 4L)
+        val tuple = Tuples.Tuple4(1.toByte(), 2, 3L, 4.0f)
         val (value1, value2, value3, value4) = tuple
-        assertEquals("one", value1)
-        assertEquals("two", value2)
-        assertEquals("three", value3)
-        assertEquals(4L, value4)
+        assertEquals(1.toByte(), value1)
+        assertEquals(2, value2)
+        assertEquals(3L, value3)
+        assertEquals(4.0f, value4)
     }
 
     @Test
     fun `can destruct Tuple5`() {
-        val tuple = Tuples.Tuple5("one", "two", "three", 4L, 5)
+        val tuple = Tuples.Tuple5(1.toByte(), 2, 3L, 4.0f, 5.0)
         val (value1, value2, value3, value4, value5) = tuple
-        assertEquals("one", value1)
-        assertEquals("two", value2)
-        assertEquals("three", value3)
-        assertEquals(4L, value4)
-        assertEquals(5, value5)
+        assertEquals(1.toByte(), value1)
+        assertEquals(2, value2)
+        assertEquals(3L, value3)
+        assertEquals(4.0f, value4)
+        assertEquals(5.0, value5)
     }
 
     @Test
     fun `can destruct Tuple6`() {
-        val tuple = Tuples.Tuple6("one", "two", "three", 4L, 5, null as Int?)
+        val tuple = Tuples.Tuple6(1.toByte(), 2, 3L, 4.0f, 5.0, BigInteger.valueOf(6))
         val (value1, value2, value3, value4, value5, value6) = tuple
-        assertEquals("one", value1)
-        assertEquals("two", value2)
-        assertEquals("three", value3)
-        assertEquals(4L, value4)
-        assertEquals(5, value5)
-        assertEquals(null, value6)
+        assertEquals(1.toByte(), value1)
+        assertEquals(2, value2)
+        assertEquals(3L, value3)
+        assertEquals(4.0f, value4)
+        assertEquals(5.0, value5)
+        assertEquals(BigInteger.valueOf(6), value6)
     }
 
     @Test
     fun `can destruct Tuple7`() {
-        val tuple = Tuples.Tuple7("one", "two", "three", 4L, 5, null as Int?, Tuples.Tuple1("seven"))
+        val tuple = Tuples.Tuple7(1.toByte(), 2, 3L, 4.0f, 5.0, BigInteger.valueOf(6), Tuples.Tuple1("seven"))
         val (value1, value2, value3, value4, value5, value6, value7) = tuple
-        assertEquals("one", value1)
-        assertEquals("two", value2)
-        assertEquals("three", value3)
-        assertEquals(4L, value4)
-        assertEquals(5, value5)
-        assertEquals(null, value6)
+        assertEquals(1.toByte(), value1)
+        assertEquals(2, value2)
+        assertEquals(3L, value3)
+        assertEquals(4.0f, value4)
+        assertEquals(5.0, value5)
+        assertEquals(BigInteger.valueOf(6), value6)
         assertEquals(Tuples.Tuple1("seven"), value7)
     }
 
     @Test
     fun `can destruct Tuple8`() {
-        val tuple = Tuples.Tuple8("one", "two", "three", 4L, 5, null as Int?, Tuples.Tuple1("seven"), 8.0)
+        val tuple = Tuples.Tuple8(1.toByte(), 2, 3L, 4.0f, 5.0, BigInteger.valueOf(6), Tuples.Tuple1("seven"), null as BigDecimal?)
         val (value1, value2, value3, value4, value5, value6, value7, value8) = tuple
-        assertEquals("one", value1)
-        assertEquals("two", value2)
-        assertEquals("three", value3)
-        assertEquals(4L, value4)
-        assertEquals(5, value5)
-        assertEquals(null, value6)
+        assertEquals(1.toByte(), value1)
+        assertEquals(2, value2)
+        assertEquals(3L, value3)
+        assertEquals(4.0f, value4)
+        assertEquals(5.0, value5)
+        assertEquals(BigInteger.valueOf(6), value6)
         assertEquals(Tuples.Tuple1("seven"), value7)
-        assertEquals(8.0, value8)
+        assertEquals(null, value8)
     }
 }

--- a/sdk/src/test/kotlin/com/pulumi/kotlin/TuplesTest.kt
+++ b/sdk/src/test/kotlin/com/pulumi/kotlin/TuplesTest.kt
@@ -1,0 +1,92 @@
+package com.pulumi.kotlin
+
+import com.pulumi.core.Tuples
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TuplesTest {
+
+    @Test
+    fun `can destruct Tuple1`() {
+        val tuple = Tuples.Tuple1("one")
+        val (value1) = tuple
+        assertEquals("one", value1)
+    }
+
+    @Test
+    fun `can destruct Tuple2`() {
+        val tuple = Tuples.Tuple2("one", "two")
+        val (value1, value2) = tuple
+        assertEquals("one", value1)
+        assertEquals("two", value2)
+    }
+
+    @Test
+    fun `can destruct Tuple3`() {
+        val tuple = Tuples.Tuple3("one", "two", "three")
+        val (value1, value2, value3) = tuple
+        assertEquals("one", value1)
+        assertEquals("two", value2)
+        assertEquals("three", value3)
+    }
+
+    @Test
+    fun `can destruct Tuple4`() {
+        val tuple = Tuples.Tuple4("one", "two", "three", 4L)
+        val (value1, value2, value3, value4) = tuple
+        assertEquals("one", value1)
+        assertEquals("two", value2)
+        assertEquals("three", value3)
+        assertEquals(4L, value4)
+    }
+
+    @Test
+    fun `can destruct Tuple5`() {
+        val tuple = Tuples.Tuple5("one", "two", "three", 4L, 5)
+        val (value1, value2, value3, value4, value5) = tuple
+        assertEquals("one", value1)
+        assertEquals("two", value2)
+        assertEquals("three", value3)
+        assertEquals(4L, value4)
+        assertEquals(5, value5)
+    }
+
+    @Test
+    fun `can destruct Tuple6`() {
+        val tuple = Tuples.Tuple6("one", "two", "three", 4L, 5, null as Int?)
+        val (value1, value2, value3, value4, value5, value6) = tuple
+        assertEquals("one", value1)
+        assertEquals("two", value2)
+        assertEquals("three", value3)
+        assertEquals(4L, value4)
+        assertEquals(5, value5)
+        assertEquals(null, value6)
+    }
+
+    @Test
+    fun `can destruct Tuple7`() {
+        val tuple = Tuples.Tuple7("one", "two", "three", 4L, 5, null as Int?, Tuples.Tuple1("seven"))
+        val (value1, value2, value3, value4, value5, value6, value7) = tuple
+        assertEquals("one", value1)
+        assertEquals("two", value2)
+        assertEquals("three", value3)
+        assertEquals(4L, value4)
+        assertEquals(5, value5)
+        assertEquals(null, value6)
+        assertEquals(Tuples.Tuple1("seven"), value7)
+    }
+
+    @Test
+    fun `can destruct Tuple8`() {
+        val tuple = Tuples.Tuple8("one", "two", "three", 4L, 5, null as Int?, Tuples.Tuple1("seven"), 8.0)
+        val (value1, value2, value3, value4, value5, value6, value7, value8) = tuple
+        assertEquals("one", value1)
+        assertEquals("two", value2)
+        assertEquals("three", value3)
+        assertEquals(4L, value4)
+        assertEquals(5, value5)
+        assertEquals(null, value6)
+        assertEquals(Tuples.Tuple1("seven"), value7)
+        assertEquals(8.0, value8)
+    }
+}


### PR DESCRIPTION
## Task

Resolves: #394 

## Description

For this to become available we'll need a new release of the core SDK + new releases of all versions. A core SDK release is in order anyway, because we're on `0.9.4` and there's three newer versions after that. **Note**: unfortunately, the fields inside tuples are marked with `@Nullable` in Java, so we had to make them nullable as well.