### PR TITLE
Update version-config.json with new majors

### DIFF
--- a/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
@@ -6,7 +6,6 @@ import org.semver4j.Semver
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 private const val RESOURCES = "src/test/resources"
 
@@ -81,12 +80,20 @@ class ReleaseScriptsTest {
     }
 
     @Test
-    fun `fails to parses Kotlin library version if no Git hash is available in a pre-release`() {
+    fun `parses a Kotlin library version even if no Git hash is available in a pre-release`() {
         val versionString = "4.7.0.2-alpha.1657304919"
+        val kotlinVersion = KotlinVersion.fromVersionString(versionString)
 
-        assertFailsWith<IllegalStateException>("Invalid version string") {
-            KotlinVersion.fromVersionString(versionString)
-        }
+        val expectedParsedVersion = KotlinVersion(Semver("4.7.0-alpha.1657304919"), 2, false)
+
+        assertEquals(
+            expectedParsedVersion,
+            kotlinVersion,
+        )
+        assertEquals(
+            versionString,
+            kotlinVersion.toString(),
+        )
     }
 
     @Test

--- a/src/main/resources/version-config.json
+++ b/src/main/resources/version-config.json
@@ -54,6 +54,15 @@
     ]
   },
   {
+    "providerName": "gcp",
+    "url": "https://raw.githubusercontent.com/pulumi/pulumi-gcp/v7.0.0/provider/cmd/pulumi-resource-gcp/schema.json",
+    "kotlinVersion": "7.0.0.0-SNAPSHOT",
+    "javaVersion": "7.0.0",
+    "javaGitTag": "v7.0.0",
+    "customDependencies": [
+    ]
+  },
+  {
     "providerName": "google-native",
     "url": "https://raw.githubusercontent.com/pulumi/pulumi-google-native/v0.31.1/provider/cmd/pulumi-resource-google-native/schema.json",
     "kotlinVersion": "0.31.1.2-SNAPSHOT",
@@ -140,6 +149,15 @@
     "kotlinVersion": "0.4.1.2-SNAPSHOT",
     "javaVersion": "0.4.1",
     "javaGitTag": "v0.4.1",
+    "customDependencies": [
+    ]
+  },
+  {
+    "providerName": "nomad",
+    "url": "https://raw.githubusercontent.com/pulumi/pulumi-nomad/v2.0.0/provider/cmd/pulumi-resource-nomad/schema.json",
+    "kotlinVersion": "2.0.0.0-SNAPSHOT",
+    "javaVersion": "2.0.0",
+    "javaGitTag": "v2.0.0",
     "customDependencies": [
     ]
   },


### PR DESCRIPTION
## Task

Resolves: None

## Description

This PR addresses the warnings found in the logs of [this build](https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/7397366420/job/20124350124) by adding new majors for gcp and nomad and changing the order of logging to avoid a silly warning about a kubernetes version. 
