### PR TITLE
add missing providers to GH actions

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -52,6 +52,8 @@ jobs:
             majorVersion: 4
           - provider: gcp
             majorVersion: 6
+          - provider: gcp
+            majorVersion: 7
           - provider: google-native
             majorVersion: 0
           - provider: aws
@@ -72,6 +74,8 @@ jobs:
             majorVersion: 4
           - provider: nomad
             majorVersion: 0
+          - provider: nomad
+            majorVersion: 2
           - provider: docker
             majorVersion: 3
           - provider: docker

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -50,6 +50,8 @@ jobs:
             majorVersion: 4
           - provider: gcp
             majorVersion: 6
+          - provider: gcp
+            majorVersion: 7
           - provider: google-native
             majorVersion: 0
           - provider: aws
@@ -70,6 +72,8 @@ jobs:
             majorVersion: 4
           - provider: nomad
             majorVersion: 0
+          - provider: nomad
+            majorVersion: 2
           - provider: docker
             majorVersion: 3
           - provider: docker


### PR DESCRIPTION
## Task

Resolves: None

## Description

I forgot to add them [here](https://github.com/VirtuslabRnD/pulumi-kotlin/pull/449). Will do the three missing releases manually.