### PR TITLE
Downgrade version of actions in self-hosted jobs

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           string: ${{ matrix.provider }}
       - name: Check out project sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Check if publication to Maven Central is necessary
         id: check-for-release
         shell: python
@@ -116,7 +116,7 @@ jobs:
               fh.write('is_release=' + str(is_release).lower())
       - name: Set up Java
         if: ${{ steps.check-for-release.outputs.is_release == 'true' }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -90,9 +90,9 @@ jobs:
             majorVersion: 3
     steps:
       - name: Check out project sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           distribution: adopt
           java-version: 11


### PR DESCRIPTION
## Task

Resolves: None

## Description

Node 20 doesn't work on our self-hosted runners. We would need to make updates to the config of those machines, for now I'm downgrading. It works on the default `ubuntu-latest` machines, so I'm only downgrading some stuff.

<img width="1070" alt="image" src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/34098778/16d7936f-9247-4961-b8a3-5e6536865fcd">

