### PR TITLE
Downgrade upload-artifact action in jobs run on a self-hosted runner

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -159,7 +159,7 @@ jobs:
           rclone copy --transfers=1024 ./docs/${{ matrix.provider }} rclone-jvm-lab:/pulumi-kotlin-docs/${{ matrix.provider }}
       - name: Upload buildSrc test report
         if: ${{ failure() && steps.publish-to-maven-central.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-src-test-report
           path: ./buildSrc/build/reports/tests/test/*

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -122,7 +122,7 @@ jobs:
           github.event_name == 'workflow_dispatch'
       - name: Upload buildSrc test report
         if: ${{ failure() && steps.publish-to-maven-local.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-src-test-report
           path: ./buildSrc/build/reports/tests/test/*


### PR DESCRIPTION
## Task

Resolves: None

## Description

Artifact upload is failing in jobs run on self-hosted runners.
<img width="1064" alt="image" src="https://github.com/VirtuslabRnD/pulumi-kotlin/assets/34098778/d872a48c-5e9b-4443-b9d8-01339493a0a6">
