### PR TITLE
Fix docs generation

### DIFF
--- a/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/step3codegen/KDocGenerator.kt
+++ b/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/step3codegen/KDocGenerator.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import kotlin.text.RegexOption.DOT_MATCHES_ALL
+import kotlin.text.RegexOption.MULTILINE
 
 private const val EXAMPLES_HEADER_REGEX = """\{\{% examples %}}\n(.*?)\{\{% example %}}(.*?)\{\{% /examples %}}"""
 private const val EXAMPLES_HEADER_REGEX_GROUP_NUMBER = 1
@@ -16,6 +17,8 @@ private const val EXAMPLE_HEADER_REGEX = """(.*?)```\w+\n.+?```"""
 private const val EXAMPLE_HEADER_REGEX_GROUP_NUMBER = 1
 
 private const val MARKDOWN_HYPERLINK = "\\[.*]"
+
+private const val MARKDOWN_EMPTY_HEADER = "^[#\\s]*#[#\\s]*\$"
 
 private const val FULL_STOP = "."
 private const val FULL_STOP_HTML_CODE = "&#46;"
@@ -64,6 +67,7 @@ private fun addDocs(kDocBuilder: KDocBuilder, kDoc: String) {
         .replace(EXAMPLES_HEADER_REGEX.toRegex(DOT_MATCHES_ALL)) {
             it.groupValues[EXAMPLES_HEADER_REGEX_GROUP_NUMBER] + "\n$examples"
         }
+        .replace(MARKDOWN_EMPTY_HEADER.toRegex(MULTILINE), "")
 
     kDocBuilder.apply(
         addCommentClosingsAndOpenings(trimmedDocs)

--- a/src/test/kotlin/org/virtuslab/pulumikotlin/codegen/step3codegen/KDocGeneratorTest.kt
+++ b/src/test/kotlin/org/virtuslab/pulumikotlin/codegen/step3codegen/KDocGeneratorTest.kt
@@ -433,6 +433,34 @@ internal class KDocGeneratorTest {
         assertExportedFileCompiles(className)
     }
 
+    @Test
+    fun `removes empty Markdown headers`() {
+        val description =
+            """# Header
+              | ## 
+              |## Examples
+              |example1
+              |#
+              |# ## 
+              |example2"""
+                .trimMargin()
+        val className = "EmptyMarkdownHeaders"
+
+        assertKDocContentEquals(
+            className,
+            description,
+            """/**
+              | * # Header
+              | * ## Examples
+              | * example1
+              | * example2
+              | */"""
+                .trimMargin(),
+        )
+
+        assertExportedFileCompiles(className)
+    }
+
     private fun assertKDocContentEquals(className: String, description: String, expected: String) {
         writeTypeToFile(
             className,


### PR DESCRIPTION
## Task

Resolves: #511 

## Description

This PR filters out lines with empty markdown header tags.
