### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -100,11 +100,11 @@ jobs:
             majorVersion: 6
     steps:
       - id: provider
-        uses: ASzc/change-string-case-action@v5
+        uses: ASzc/change-string-case-action@v6
         with:
           string: ${{ matrix.provider }}
       - name: Check out project sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check if publication to Maven Central is necessary
         id: check-for-release
         shell: python
@@ -124,7 +124,7 @@ jobs:
               fh.write('is_release=' + str(is_release).lower())
       - name: Set up Java
         if: ${{ steps.check-for-release.outputs.is_release == 'true' }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 21
@@ -170,7 +170,7 @@ jobs:
           rclone copy --transfers=1024 ./docs/${{ matrix.provider }} rclone-jvm-lab:/pulumi-kotlin-docs/${{ matrix.provider }}
       - name: Upload buildSrc test report
         if: ${{ failure() && steps.publish-to-maven-central.outcome == 'failure' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-src-test-report
           path: ./buildSrc/build/reports/tests/test/*
@@ -195,7 +195,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create pull request
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:
           title: Prepare for next development phase
           body: |

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -98,9 +98,9 @@ jobs:
             majorVersion: 6
     steps:
       - name: Check out project sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 21
@@ -136,7 +136,7 @@ jobs:
           github.event_name == 'workflow_dispatch'
       - name: Upload buildSrc test report
         if: ${{ failure() && steps.publish-to-maven-local.outcome == 'failure' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-src-test-report
           path: ./buildSrc/build/reports/tests/test/*


### PR DESCRIPTION
## Task

Resolves: #513

## Description

I managed to update the version of runners + CentOS, see related PR: https://github.com/VirtuslabRnD/jvm-lab/pull/120 (I already used `pulumi up` on it). You can see a trial run with updated versions here: https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/9339671477
