### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -156,11 +156,15 @@ jobs:
           version=$(echo $file_name | sed -e "s/^pulumi-${{ matrix.provider }}-kotlin-//" -e "s/-javadoc.jar$//")
           mkdir -p ./docs/${{ matrix.provider }}/$version
           mv ./build/dokka/pulumi${{ steps.provider.outputs.capitalized }}${{ matrix.major-version }}Javadoc/* ./docs/${{ matrix.provider }}/$version
+      - name: Install GitHub CLI # this can be moved to runner configuration
+        if: ${{ steps.check-for-release.outputs.is_release == 'true' && !contains(matrix.runs-on, 'ubuntu-latest') }}
+        uses: dev-hanz-ops/install-gh-cli-action@v0.1.0
+      - name: Install missing tools # this can be moved to runner configuration
+        if: ${{ steps.check-for-release.outputs.is_release == 'true' && !contains(matrix.runs-on, 'ubuntu-latest') }}
+        run: yum -y install wget zip
       - name: Install Rclone
         if: ${{ steps.check-for-release.outputs.is_release == 'true' }}
-        run: |
-          yum -y install unzip
-          curl https://rclone.org/install.sh | bash || true
+        uses: AnimMouse/setup-rclone@v1
       - name: Configure Rclone
         if: ${{ steps.check-for-release.outputs.is_release == 'true' }}
         run: |

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -156,10 +156,10 @@ jobs:
           version=$(echo $file_name | sed -e "s/^pulumi-${{ matrix.provider }}-kotlin-//" -e "s/-javadoc.jar$//")
           mkdir -p ./docs/${{ matrix.provider }}/$version
           mv ./build/dokka/pulumi${{ steps.provider.outputs.capitalized }}${{ matrix.major-version }}Javadoc/* ./docs/${{ matrix.provider }}/$version
-      - name: Install GitHub CLI # this can be moved to runner configuration
+      - name: Install GitHub CLI # TODO: move this step to runner VM setup
         if: ${{ steps.check-for-release.outputs.is_release == 'true' && !contains(matrix.runs-on, 'ubuntu-latest') }}
         uses: dev-hanz-ops/install-gh-cli-action@v0.1.0
-      - name: Install missing tools # this can be moved to runner configuration
+      - name: Install missing tools # TODO: move this step to runner VM setup
         if: ${{ steps.check-for-release.outputs.is_release == 'true' && !contains(matrix.runs-on, 'ubuntu-latest') }}
         run: yum -y install wget zip
       - name: Install Rclone

--- a/.github/workflows/rclone.conf
+++ b/.github/workflows/rclone.conf
@@ -1,7 +1,7 @@
 [rclone-jvm-lab]
 type = google cloud storage
 project_number = 954450653667
-service_account_file = /root/.config/gcp-key.json
+service_account_file = ~/.config/gcp-key.json
 object_acl = publicRead
 bucket_acl = publicRead
 location = europe-west1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,14 +40,14 @@ dependencies {
 
     implementation("com.google.code.gson:gson:2.11.0")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.2")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.6.0")
     testImplementation(kotlin("test", "1.9.22"))
-    testImplementation("com.google.cloud:google-cloud-compute:1.54.0")
-    testImplementation("com.azure:azure-identity:1.12.1")
-    testImplementation("com.azure.resourcemanager:azure-resourcemanager-compute:2.39.0")
-    testImplementation("io.kubernetes:client-java:20.0.1")
-    testImplementation("io.github.cdklabs:projen:0.81.16")
+    testImplementation("com.google.cloud:google-cloud-compute:1.62.0")
+    testImplementation("com.azure:azure-identity:1.14.0")
+    testImplementation("com.azure.resourcemanager:azure-resourcemanager-compute:2.43.0")
+    testImplementation("io.kubernetes:client-java:21.0.2")
+    testImplementation("io.github.cdklabs:projen:0.88.5")
 }
 
 tasks.test {

--- a/examples/azure-native-sample-project/pom.xml
+++ b/examples/azure-native-sample-project/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-random-kotlin</artifactId>
-            <version>4.13.2.0-SNAPSHOT</version>
+            <version>4.16.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/examples/azure-native-sample-project/pom.xml
+++ b/examples/azure-native-sample-project/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-azure-native-kotlin</artifactId>
-            <version>1.103.0.0-SNAPSHOT</version>
+            <version>2.60.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>

--- a/examples/azure-sample-project/pom.xml
+++ b/examples/azure-sample-project/pom.xml
@@ -22,12 +22,12 @@
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-azure-kotlin</artifactId>
-            <version>5.44.1.0-SNAPSHOT</version>
+            <version>5.87.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.virtuslab</groupId>
             <artifactId>pulumi-random-kotlin</artifactId>
-            <version>4.13.2.0-SNAPSHOT</version>
+            <version>4.16.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/examples/azure-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/azure-sample-project/src/main/kotlin/project/Main.kt
@@ -18,6 +18,9 @@ fun main() {
         }
 
         val resourceGroup = resourceGroup("azure-sample-project") {
+            args {
+                location(ctx.config("azure").get("location").orElse(null))
+            }
             opts {
                 provider(provider)
             }
@@ -28,9 +31,6 @@ fun main() {
                 resourceGroupName(resourceGroup.name)
                 addressSpaces("10.0.0.0/16")
             }
-            opts {
-                provider(provider)
-            }
         }
 
         val internalSubnet = subnet("internal-subnet") {
@@ -38,9 +38,6 @@ fun main() {
                 resourceGroupName(resourceGroup.name)
                 virtualNetworkName(mainVirtualNetwork.name)
                 addressPrefixes("10.0.2.0/24")
-            }
-            opts {
-                provider(provider)
             }
         }
 
@@ -52,9 +49,6 @@ fun main() {
                     subnetId(internalSubnet.id)
                     privateIpAddressAllocation("Dynamic")
                 }
-            }
-            opts {
-                provider(provider)
             }
         }
 
@@ -92,9 +86,6 @@ fun main() {
                 }
                 tags("foo" to "bar")
                 deleteOsDiskOnTermination(true)
-            }
-            opts {
-                provider(provider)
             }
         }
         ctx.export("virtualMachineId", virtualMachine.id)

--- a/examples/azure-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/azure-sample-project/src/main/kotlin/project/Main.kt
@@ -2,6 +2,7 @@ package project
 
 import com.pulumi.azure.compute.kotlin.virtualMachine
 import com.pulumi.azure.core.kotlin.resourceGroup
+import com.pulumi.azure.kotlin.azureProvider
 import com.pulumi.azure.network.kotlin.networkInterface
 import com.pulumi.azure.network.kotlin.subnet
 import com.pulumi.azure.network.kotlin.virtualNetwork
@@ -10,12 +11,24 @@ import com.pulumi.random.kotlin.randomPassword
 
 fun main() {
     Pulumi.run { ctx ->
-        val resourceGroup = resourceGroup("azure-sample-project")
+        val provider = azureProvider("azure-provider") {
+            args {
+                skipProviderRegistration(true)
+            }
+        }
+        val resourceGroup = resourceGroup("azure-sample-project") {
+            opts {
+                provider(provider)
+            }
+        }
 
         val mainVirtualNetwork = virtualNetwork("virtual-network") {
             args {
                 resourceGroupName(resourceGroup.name)
                 addressSpaces("10.0.0.0/16")
+            }
+            opts {
+                provider(provider)
             }
         }
 
@@ -24,6 +37,9 @@ fun main() {
                 resourceGroupName(resourceGroup.name)
                 virtualNetworkName(mainVirtualNetwork.name)
                 addressPrefixes("10.0.2.0/24")
+            }
+            opts {
+                provider(provider)
             }
         }
 
@@ -36,12 +52,18 @@ fun main() {
                     privateIpAddressAllocation("Dynamic")
                 }
             }
+            opts {
+                provider(provider)
+            }
         }
 
         val randomAdminPassword = randomPassword("random-admin-password") {
             args {
                 length(20)
                 special(true)
+            }
+            opts {
+                provider(provider)
             }
         }
 
@@ -72,6 +94,9 @@ fun main() {
                 }
                 tags("foo" to "bar")
                 deleteOsDiskOnTermination(true)
+            }
+            opts {
+                provider(provider)
             }
         }
         ctx.export("virtualMachineId", virtualMachine.id)

--- a/examples/azure-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/azure-sample-project/src/main/kotlin/project/Main.kt
@@ -62,9 +62,6 @@ fun main() {
                 length(20)
                 special(true)
             }
-            opts {
-                provider(provider)
-            }
         }
 
         val virtualMachine = virtualMachine("virtual-machine") {

--- a/examples/azure-sample-project/src/main/kotlin/project/Main.kt
+++ b/examples/azure-sample-project/src/main/kotlin/project/Main.kt
@@ -16,6 +16,7 @@ fun main() {
                 skipProviderRegistration(true)
             }
         }
+
         val resourceGroup = resourceGroup("azure-sample-project") {
             opts {
                 provider(provider)

--- a/src/main/resources/version-config-e2e.json
+++ b/src/main/resources/version-config-e2e.json
@@ -1,19 +1,19 @@
 [
   {
     "providerName": "random",
-    "url": "https://raw.githubusercontent.com/pulumi/pulumi-random/v4.13.2/provider/cmd/pulumi-resource-random/schema.json",
-    "kotlinVersion": "4.13.2.0-SNAPSHOT",
-    "javaVersion": "4.13.2",
-    "javaGitTag": "v4.13.2",
+    "url": "https://raw.githubusercontent.com/pulumi/pulumi-random/v4.16.4/provider/cmd/pulumi-resource-random/schema.json",
+    "kotlinVersion": "4.16.4.0-SNAPSHOT",
+    "javaVersion": "4.16.4",
+    "javaGitTag": "v4.16.4",
     "customDependencies": [
     ]
   },
   {
     "providerName": "azure",
-    "url": "https://gist.githubusercontent.com/jplewa/0897e9ca654d1f029f37162ce8ccba7f/raw/cf5f0801f2c03765316978cf4055be34340346bb/schema-azure-v5.44.1-subset-for-build.json",
-    "kotlinVersion": "5.44.1.0-SNAPSHOT",
-    "javaVersion": "5.44.1",
-    "javaGitTag": "v5.44.1",
+    "url": "https://gist.githubusercontent.com/jplewa/3a13cf2ed18aa39de8cb9189dd487356/raw/6aa6c7929106aad8661478080eafb45e5cf03e8f/schema-azure-v5.87.0-subset-for-build.json",
+    "kotlinVersion": "5.87.0.0-SNAPSHOT",
+    "javaVersion": "5.87.0",
+    "javaGitTag": "v5.87.0",
     "customDependencies": [
     ]
   },

--- a/src/main/resources/version-config-e2e.json
+++ b/src/main/resources/version-config-e2e.json
@@ -19,10 +19,10 @@
   },
   {
     "providerName": "azure-native",
-    "url": "https://gist.githubusercontent.com/jplewa/cea43edd61c3284b29c037cd094e0e77/raw/f32ad6c02c8b90efcea1ae10a84a2d92951bab17/schema-azure-native-v1.103.0-subset-for-build.json",
-    "kotlinVersion": "1.103.0.0-SNAPSHOT",
-    "javaVersion": "1.103.0",
-    "javaGitTag": "v1.103.0",
+    "url": "https://gist.githubusercontent.com/jplewa/9f1b6473760f8788968411a181711a8d/raw/c6ea26c662a75d7a9e4b2551fffb449c9eca3bc3/schema-azure-native-v2.60.1-subset-for-build.json",
+    "kotlinVersion": "2.60.1.0-SNAPSHOT",
+    "javaVersion": "2.60.1",
+    "javaGitTag": "v2.60.1",
     "customDependencies": [
     ]
   },


### PR DESCRIPTION
## Task

Resolves: None

## Description

Splitting providers into those that can be run on default GH runners on those that require custom runners with extra RAM ([here](https://github.com/VirtuslabRnD/pulumi-kotlin/pull/708)) lead to some issues with the release pipeline, specifically with the installation of Rclone (due to missing gh, zip, and wget dependencies). In the future this can be addressed in our VM startup script, but I didn't want to mess with it right now.


