### PR TITLE
Move GitLab to self-hosted runner

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -86,7 +86,7 @@ jobs:
             runs-on: [ ubuntu-latest ]
           - provider: gitlab
             major-version: 8
-            runs-on: [ ubuntu-latest ]
+            runs-on: [ self-hosted, active ]
           - provider: digitalocean
             major-version: 4
             runs-on: [ ubuntu-latest ]

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -79,7 +79,7 @@ jobs:
             runs-on: [ ubuntu-latest ]
           - provider: gitlab
             major-version: 8
-            runs-on: [ ubuntu-latest ]
+            runs-on: [ self-hosted, active ]
           - provider: digitalocean
             major-version: 4
             runs-on: [ ubuntu-latest ]


### PR DESCRIPTION
## Task

Resolves: None

## Description

It looks like the 8 GB of RAM is not sufficient, the build is flaky: https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/11418790179/job/31772643392
