### PR TITLE
Move GitLab back to default runner

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -86,7 +86,7 @@ jobs:
             runs-on: [ ubuntu-latest ]
           - provider: gitlab
             major-version: 8
-            runs-on: [ self-hosted, active ]
+            runs-on: [ ubuntu-latest ]
           - provider: digitalocean
             major-version: 4
             runs-on: [ ubuntu-latest ]

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -79,7 +79,7 @@ jobs:
             runs-on: [ ubuntu-latest ]
           - provider: gitlab
             major-version: 8
-            runs-on: [ self-hosted, active ]
+            runs-on: [ ubuntu-latest ]
           - provider: digitalocean
             major-version: 4
             runs-on: [ ubuntu-latest ]


### PR DESCRIPTION
## Task

Resolves: None

## Description

I moved GitLab to a custom runner back in https://github.com/VirtuslabRnD/pulumi-kotlin/pull/721 to fix some weird issues that I thought were related to RAM. Turns out they weren't as we still get them even after upgrading the amount of RAM:
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/7cc178d8-473f-4e34-b34e-24e83466504f">
https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/11429027858/job/31794941994?pr=725

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/ed699eee-4e32-4d82-b741-6e9551063da9">

https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/11418790179/job/31779317479

Therefore, we can move back to a standard runner. The errors will have to be resolved somehow in the future.

