### PR TITLE
Update -Xss value

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -86,7 +86,7 @@ jobs:
             runs-on: [ ubuntu-latest ]
           - provider: gitlab
             major-version: 8
-            runs-on: [ self-hosted, active ]
+            runs-on: [ ubuntu-latest ]
           - provider: digitalocean
             major-version: 4
             runs-on: [ ubuntu-latest ]

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -144,7 +144,7 @@ jobs:
             -Psigning.key.password="${{ secrets.GPG_KEY_PASSWORD }}" \
             -Psonatype.username="${{ secrets.SONATYPE_USERNAME }}" \
             -Psonatype.password="${{ secrets.SONATYPE_PASSWORD }}" \
-            -Dorg.gradle.jvmargs=-Xmx50g \
+            -Dorg.gradle.jvmargs="-Xmx50g -Xss2048k" \
             -Dorg.gradle.workers.max=1 \
             -Dorg.gradle.daemon=false \
             -Pkotlin.compiler.execution.strategy=in-process \

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -121,7 +121,7 @@ jobs:
         id: publish-to-maven-local
         run: |
           ./gradlew publishPulumi${{ matrix.provider }}${{ matrix.major-version }}PublicationToMavenLocal \
-            -Dorg.gradle.jvmargs=-Xmx50g \
+            -Dorg.gradle.jvmargs="-Xmx50g -Xss2048k" \
             -Dorg.gradle.workers.max=1 \
             -Dorg.gradle.daemon=false \
             -Pkotlin.compiler.execution.strategy=in-process \

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -79,7 +79,7 @@ jobs:
             runs-on: [ ubuntu-latest ]
           - provider: gitlab
             major-version: 8
-            runs-on: [ self-hosted, active ]
+            runs-on: [ ubuntu-latest ]
           - provider: digitalocean
             major-version: 4
             runs-on: [ ubuntu-latest ]


### PR DESCRIPTION
## Task

Resolves: None

## Description

This mitigates the following compilation error:
```
e: org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during psi2ir
File being compiled: (672,9) in /root/_work/pulumi-kotlin/pulumi-kotlin/build/generated-src/gitlab8/com/pulumi/gitlab/kotlin/ApplicationSettingsArgs.kt
The root cause java.lang.StackOverflowError was thrown at: java.base/java.lang.ClassLoader.defineClass1(Native Method)
null: KtDotQualifiedExpression:
com.pulumi.gitlab.ApplicationSettingsArgs.builder()
            .abuseNotificationEmail(abuseNotificationEmail?.applyValue({ args0 -> args0 }))
            .adminMode(adminMode?.applyValue({ args0 -> args0 }))
            .afterSignOutPath(afterSignOutPath?.applyValue({ args0 -> args0 }))
            .afterSignUpText(afterSignUpText?.applyValue({ args0 -> args0 }))
            .akismetApiKey(akismetApiKey?.applyValue({ args0 -> args0 }))
            .akismetEnabled(akismetEnabled?.applyValue({ args0 -> args0 }))
            .allowAccountDeletion(allowAccountDeletion?.applyValue({ args0 -> args0 }))
            .allowGroupOwnersToManageLdap(allowGroupOwnersToManageLdap?.applyValue({ args0 -> args0 }))
            .allowLocalRequestsFromSystemHooks(
                allowLocalRequestsFromSystemHooks?.applyValue({ args0 ->
                    args0
                }),
            )
...
```
https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/11459232264/job/33149512961

The error was preventing [this release](https://github.com/VirtuslabRnD/pulumi-kotlin/pull/725).