### PR TITLE
Switch release cron to every other day

### DIFF
--- a/.github/workflows/update_schemas.yml
+++ b/.github/workflows/update_schemas.yml
@@ -2,7 +2,7 @@ name: Update schemas
 
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 6 */2 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Task

Resolves: None

## Description

Let's not waste resources on releases with a single provider. If we do it every other day, there's a better chance of having several providers released at once.
