### PR TITLE
Update release cron

### DIFF
--- a/.github/workflows/update_schemas.yml
+++ b/.github/workflows/update_schemas.yml
@@ -2,7 +2,7 @@ name: Update schemas
 
 on:
   schedule:
-    - cron: '0 6 */2 * *'
+    - cron: '0 6 * * 1-5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Task

Resolves: None

## Description

This updates the release cron expression to run daily between Monday and Friday. After the changes done in https://github.com/VirtuslabRnD/pulumi-kotlin/pull/829, we will no longer open a release PR unless 5 providers are updated in it, which will help limit the number of GH Actions job - there is no need to run it every other day anymore.