### PR TITLE
Add Cloudflare and Azure Native majors

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           - provider: cloudflare
-            major-version: 5
+            major-version: 6
             runs-on: [ ubuntu-latest ]
           - provider: slack
             major-version: 0
@@ -73,7 +73,7 @@ jobs:
             major-version: 6
             runs-on: [ self-hosted, active ]
           - provider: azure-native
-            major-version: 2
+            major-version: 3
             runs-on: [ self-hosted, active ]
           - provider: kubernetes
             major-version: 4

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         include:
           - provider: cloudflare
-            major-version: 5
+            major-version: 6
             runs-on: [ ubuntu-latest ]
           - provider: slack
             major-version: 0
@@ -66,7 +66,7 @@ jobs:
             major-version: 6
             runs-on: [ self-hosted, active ]
           - provider: azure-native
-            major-version: 2
+            major-version: 3
             runs-on: [ self-hosted, active ]
           - provider: kubernetes
             major-version: 4

--- a/src/main/resources/version-config.json
+++ b/src/main/resources/version-config.json
@@ -14,6 +14,14 @@
     "javaVersion": "5.49.1",
     "javaGitTag": "v5.49.1",
     "customDependencies": []
+  },  
+  {
+    "providerName": "cloudflare",
+    "url": "https://raw.githubusercontent.com/pulumi/pulumi-cloudflare/v6.0.0/provider/cmd/pulumi-resource-cloudflare/schema.json",
+    "kotlinVersion": "6.0.0.0-SNAPSHOT",
+    "javaVersion": "6.0.0",
+    "javaGitTag": "v6.0.0",
+    "customDependencies": []
   },
   {
     "providerName": "slack",
@@ -141,6 +149,14 @@
     "kotlinVersion": "2.90.0.1-SNAPSHOT",
     "javaVersion": "2.90.0",
     "javaGitTag": "v2.90.0",
+    "customDependencies": []
+  },
+  {
+    "providerName": "azure-native",
+    "url": "https://raw.githubusercontent.com/pulumi/pulumi-azure-native/v3.0.0/provider/cmd/pulumi-resource-azure-native/schema.json",
+    "kotlinVersion": "3.0.0.0-SNAPSHOT",
+    "javaVersion": "3.0.0",
+    "javaGitTag": "v3.0.0",
     "customDependencies": []
   },
   {


### PR DESCRIPTION
## Task

Resolves: None

## Description
Cloudflare v6 and Azure Native v3 can be added.
![image](https://github.com/user-attachments/assets/2cf36b12-5b39-4d38-98f7-b4899a111a69)
