### PR TITLE
Fix azure-native code generation

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -47,7 +47,7 @@ jobs:
         include:
           - provider: cloudflare
             major-version: 6
-            runs-on: [ ubuntu-latest ]
+            runs-on: [ self-hosted, active ]
           - provider: slack
             major-version: 0
             runs-on: [ ubuntu-latest ]

--- a/.github/workflows/publish_to_maven_local.yml
+++ b/.github/workflows/publish_to_maven_local.yml
@@ -40,7 +40,7 @@ jobs:
         include:
           - provider: cloudflare
             major-version: 6
-            runs-on: [ ubuntu-latest ]
+            runs-on: [ self-hosted, active ]
           - provider: slack
             major-version: 0
             runs-on: [ ubuntu-latest ]

--- a/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/utils/Constants.kt
+++ b/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/utils/Constants.kt
@@ -8,5 +8,8 @@ object Constants {
         "azure-native:network:IpAllocationMethod" to "azure-native:network:IPAllocationMethod",
         "alicloud:alb/ListenerXforwardedForConfig:ListenerXforwardedForConfig" to
             "alicloud:alb/ListenerXForwardedForConfig:ListenerXForwardedForConfig",
+        // note: this is wrong, but it's what is generated in Java
+        // see: https://github.com/pulumi/pulumi-azure-native/issues/4107
+        "azure-native:apimanagement:LlmDiagnosticSettings" to "azure-native:apimanagement:LLMDiagnosticSettings",
     )
 }

--- a/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/utils/Constants.kt
+++ b/src/main/kotlin/org/virtuslab/pulumikotlin/codegen/utils/Constants.kt
@@ -8,6 +8,7 @@ object Constants {
         "azure-native:network:IpAllocationMethod" to "azure-native:network:IPAllocationMethod",
         "alicloud:alb/ListenerXforwardedForConfig:ListenerXforwardedForConfig" to
             "alicloud:alb/ListenerXForwardedForConfig:ListenerXForwardedForConfig",
+        "azure-native:dbforpostgresql:StorageAutogrow" to "azure-native:dbforpostgresql:StorageAutoGrow",
         // note: this is wrong, but it's what is generated in Java
         // see: https://github.com/pulumi/pulumi-azure-native/issues/4107
         "azure-native:apimanagement:LlmDiagnosticSettings" to "azure-native:apimanagement:LLMDiagnosticSettings",


### PR DESCRIPTION
## Task

Resolves: None

## Description

![image](https://github.com/user-attachments/assets/eb5661ea-aaec-4f73-b206-e779f703e3d5)
![image](https://github.com/user-attachments/assets/85f00390-be89-4aa6-a273-b8609236ee32)
https://github.com/VirtuslabRnD/pulumi-kotlin/actions/runs/14478274216/job/40614820196

The Cloudflare provider had to be moved to a self-hosted runner due to memory issues. This Azure Native fix is a temporary workaround until https://github.com/pulumi/pulumi-azure-native/issues/4107 is fixed. 
