### PR TITLE
Fix ReleaseScriptsTest

### DIFF
--- a/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/ReleaseScriptsTest.kt
@@ -120,6 +120,7 @@ class ReleaseScriptsTest {
             readmeFile = temporaryBeforeReadmeUpdateFile,
             skipPreReleaseVersions = false,
             fastForwardToMostRecentVersion = false,
+            minimumNumberOfUpdates = 1,
         )
 
         assertEquals(


### PR DESCRIPTION
## Task

Resolves: None

## Description

This PR fixes `ReleaseScriptsTest`, which got broken in https://github.com/VirtuslabRnD/pulumi-kotlin/pull/829.
